### PR TITLE
fixed a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Table of contents:
 * [Blog](http://angularjs.blogspot.com/)
 * [Documentation](https://angular.io/docs/js/latest/)
 * [Cheatsheet](https://angular.io/guide/cheatsheet)
-* [Getting Started Guide](https://angular.io/docs/js/latest/quickstart)
+* [Getting Started Guide](https://angular.io/guide/quickstart)
 * [GitHub Repo](https://github.com/angular/angular)
 
 #### Community


### PR DESCRIPTION
broken link - "Getting Started Guide" link (line 105)
changed FROM: https://angular.io/docs/js/latest/quickstart TO: https://angular.io/guide/quickstart