### PR TITLE
Add Blox Material library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Table of contents:
 * [mdl-ext](https://www.npmjs.com/package/mdl-ext) Material Design Lite Ext (carusel, grid, lightbox, selectfield, sticky header, ...)
 * [ng2-materialize](https://github.com/sherweb/ng2-materialize) An Angular 2 wrap around Materialize library
 * [Material Light](https://github.com/YagoLopez/material-light) Light, fast and easy to use Material Design components for Angular 2+ (Especially for mobile UI). There are several alternatives but this one has added value and advantages in my opinion (Take a loot at the Readme.md for details). There is also an online demo to see it in action. (API documentation is still lacking but in process).
+* [Blox Material](https://github.com/src-zone/material) A lightweight Material Design library for Angular, based upon Google's Material Components for the Web.
 
 #### Cheatsheet
 * [Official Angular 2 Cheatsheet](https://angular.io/guide/cheatsheet)


### PR DESCRIPTION
Blox Material is a lightweight Material Design library based upon Google's Material Components for the Web.