### PR TITLE
edited a header due to wrong linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Awesome list of [Angular](https://angular.io/) seed repos, starters, boilerplate
 > If you're looking for AngularJS (version 1.x.x) please visit https://github.com/gianarb/awesome-angularjs
 
 ##### Current Angular version:
+
 [![npm version](https://badge.fury.io/js/%40angular%2Fcore.svg)](https://www.npmjs.com/~angular)
 
 ##### Current Browser support for Angular:
+
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/angular2-ci.svg)](https://saucelabs.com/u/angular2-ci)
 
 <p align="center">
@@ -23,6 +25,7 @@ Awesome list of [Angular](https://angular.io/) seed repos, starters, boilerplate
 </p>
 
 Table of contents:
+
 * [Angular](#angular)
   * [Official Resources](#official-resources)
   * [Community](#community)
@@ -83,9 +86,11 @@ Table of contents:
 * [NgRx](#ngrx)
 
 ### Angular
+
 > Angular is a development platform for building mobile and desktop web applications.
 
 #### Official Resources
+
 * [Site](https://angular.io)
 * [Blog](https://blog.angular.io)
 * [Documentation](https://angular.io/docs)
@@ -94,6 +99,7 @@ Table of contents:
 * [GitHub Repo](https://github.com/angular/angular)
 
 #### Community
+
 * `#angular2` channel on Freenode IRC Server
 * [`#angular`](https://twitter.com/hashtag/angular) hashtag on Twitter
 * [Gitter Channel](https://gitter.im/angular/angular)
@@ -121,6 +127,7 @@ Table of contents:
 * [@robwormald](https://twitter.com/robwormald)
 
 #### Experts on Twitter
+
 > List of Angular experts you should follow on Twitter (in no particular order). This list is by no means complete.
 
 * [@gdi2290](https://twitter.com/gdi2290)
@@ -135,6 +142,7 @@ Table of contents:
 * [@jeffbcross](https://twitter.com/jeffbcross)
 
 ##### [Google Developer Experts](https://developers.google.com/experts/all/technology/web-technologies)
+
 * [Jack Franklin](https://twitter.com/jack_franklin)
 * [Thierry Chatel](https://twitter.com/ThierryChatel)
 * [Uri Shaked](https://twitter.com/urishaked)
@@ -163,9 +171,11 @@ Table of contents:
 * [**{{** add_expert **}}**](https://github.com/gdi2290/awesome-angular/edit/gh-pages/README.md)
 
 #### Server-Side Rendering
+
 * [Angular Universal Repository (GitHub)](https://github.com/angular/universal)
 
 #### Material Design
+
 * [Official Angular Material Design (GitHub)](https://github.com/angular/material2)
 * [md2](https://www.npmjs.com/package/md2) Angular2 based Material Design components, directives and services are Accordion, Autocomplete, Collapse, Colorpicker, Datepicker, Dialog(Modal), Menu, Multiselect, Select, Switch, Tabs, Tags(Chips), Toast and Tooltip.
 * [ng2-material](https://www.npmjs.com/package/ng2-material) set of material2 examples and extra components (data table, dialog, ...) built on top of @angular2-material/core
@@ -176,6 +186,7 @@ Table of contents:
 * [Blox Material](https://github.com/src-zone/material) A lightweight Material Design library for Angular, based upon Google's Material Components for the Web.
 
 #### Cheatsheet
+
 * [Official Angular Cheatsheet](https://angular.io/guide/cheatsheet)
 * [Dart API Cheatsheet](https://docs.google.com/document/d/1FYyA-b9rc2UtlYyQXjW7lx4Y08MSpuWcbbuqVCxHga0/edit#heading=h.34sus6g4zss3)
 * [Angular Dart cheatsheet](https://github.com/andresaraujo/angular2_cheatsheet_dart)
@@ -184,47 +195,60 @@ Table of contents:
 #### Features
 
 ###### Directives
+
 Directives allow you to attach behavior to elements in the DOM.
 
 ###### Components
+
 A component is a directive which uses shadow DOM to create encapsulate visual behavior. Components are typically used to create UI widgets or to break up the application into smaller components.
 
 ##### View
+
 A View is a core primitive used by angular to render the DOM tree.
 
 ##### Templates
+
 Templates are markup which is added to HTML to declaratively describe how the application model should be
 projected to DOM as well as which DOM events should invoke which methods on the controller.
 
 ##### Change detection
+
 Every component gets a change detector responsible for checking the bindings defined in its template.
 
 ##### Dependency Injection
+
 Angular 1.x has two APIs for injecting dependencies into a directive. Angular 2 unifies the two APIs, making the code easier to understand and test.
 
 ##### Pipes
+
 Pipes can be appended on the end of the expressions to translate the value to a different format.
 
 ##### Web Workers
+
 WebWorker support in Angular is designed to make it easy to leverage parallelization in your web application.
 When you choose to run your application in a WebWorker angular runs both your application's logic and the
 majority of the core angular framework in a WebWorker.
 
 ##### HTTP
+
 Http is available as an injectable class, with methods to perform http requests. Calling request returns an EventEmitter which will emit a single Response when a response is received.
+
 * [Introduction to HTTP in Angular 2](http://www.syntaxsuccess.com/viewarticle/angular-2.0-and-http)
 
 ##### Router
+
 * [Offical Router](https://angular.io/guide/router.html#sts=Router%20imports)
 * [ui-router](https://github.com/angular-ui/ui-router)
 
 ##### Test
+
 * [Testing Http services in Angular 2 with Jasmine](http://chariotsolutions.com/blog/post/testing-http-services-angular-2-jasmine/)
 * [Testing UI Components with the TestComponentBuilder](http://chariotsolutions.com/blog/post/testing-angular-2-components-unit-tests-testcomponentbuilder/)
-[**{{** help_out **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
-<br>[Read more »](features/Test.md)
+  [**{{** help_out **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
+  <br>[Read more »](features/Test.md)
 
 ##### Ahead-of-Time Compilation
+
 * [Official Documentation](https://angular.io/guide/aot-compiler)
 * [Ahead-of-Time Compilation in Angular](http://blog.mgechev.com/2016/08/14/ahead-of-time-compilation-angular-offline-precompilation/)
 * [Building an Angular Application for Production](http://blog.mgechev.com/2016/06/26/tree-shaking-angular2-production-build-rollup-javascript/)
@@ -234,21 +258,24 @@ Http is available as an injectable class, with methods to perform http requests.
 * [Code Example with Rollup](https://github.com/mgechev/angular2-ngc-rollup-build)
 
 #### Angular CLI
+
 * [Official web page](https://cli.angular.io/)
 * [Official repository](https://github.com/angular/angular-cli)
 
 #### Webpack
+
 * [Official web page](https://webpack.js.org)
 * [Angular Webpack Starter from PatrickJS](https://github.com/gdi2290/angular-starter)
 * [Angular Webpack from preboot](https://github.com/preboot/angular-webpack)
 * [Angular Nightly Webpack Starter](https://github.com/qdouble/angular-webpack2-starter)
 * [Angular Webpack with Visual Studio ASP.NET Core from Damien Bowden](https://github.com/damienbod/AngularWebpackVisualStudio)
 * [Angular Typescript Webpack from schempy](https://github.com/schempy/angular2-typescript-webpack)
-* [Angular Webpack  Tour of Heroes from michaelbazos](https://github.com/michaelbazos/angular-starter) - Tour of Heroes official typescript tutorial built with webpack
+* [Angular Webpack Tour of Heroes from michaelbazos](https://github.com/michaelbazos/angular-starter) - Tour of Heroes official typescript tutorial built with webpack
 * [Angular Webpack + rxjs + modules](https://github.com/jorgeas80/angular2-webpack-toh)
 * [Shared Webpack config for Angular development by fulls1z3](https://github.com/ng-seed/angular-webpack-config)
 
 #### Series
+
 * Ionic
   * Angular
     * [Introduction](http://blog.ionic.io/angular-2-series-introduction/)
@@ -269,6 +296,7 @@ Http is available as an injectable class, with methods to perform http requests.
     * [Part 1 Let’s learn how to install and setup AngularFire2 4.0](https://medium.com/letsboot/lets-learn-how-to-install-and-setup-angularfire2-4-0-135d72bb0a41)
 
 #### Video Tutorials
+
 * [Egghead.io - Angular 2](https://egghead.io/technologies/angular2)
 * [Egghead.io - Build Redux Style Applications with Angular2, RxJS, and ngrx/store](https://egghead.io/courses/building-a-time-machine-with-angular-2-and-rxjs)
 * [HiRez.io - Angular Basics](https://www.hirez.io/c/angular-basics-1/e/episode-1-course-overview)
@@ -287,10 +315,12 @@ Http is available as an injectable class, with methods to perform http requests.
 * [Angular 4 Master Class: Beginner to Advanced](https://www.udemy.com/angular-crash-course-for-beginners)
 
 #### Style Guides
+
 * [Official Angular Style guide](https://angular.io/guide/styleguide)
 * [Shared TSLint & codelyzer rules by fulls1z3](https://github.com/ng-seed/angular-tslint-rules)
 
 #### Angular Connect
+
 * [Keynote – Brad Green, Igor Minar and Jules Kremer](https://www.youtube.com/watch?v=UxjgUjVpe24)
 * [Testing strategies with Angular 2 – Julie Ralph](https://www.youtube.com/watch?v=C0F2E-PRm44)
 * [Building native mobile apps with Angular 2 0 and NativeScript​ - Sebastian Witalec](https://www.youtube.com/watch?v=4SbiiyRSIwo)
@@ -303,6 +333,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [Creating realtime apps with Angular 2 and Meteor - Uri Goldshtein](https://www.youtube.com/watch?v=3FT0BqYASCo)
 
 #### Books
+
 * [ng-book 2](https://www.ng-book.com/2/) `fullstack.io`
 * [Become a ninja with Angular 2](https://books.ninja-squad.com/angular) `Ninja Squad`
 * [Angular Development with TypeScript](https://www.manning.com/books/angular-2-development-with-typescript) `Manning Publications`
@@ -310,12 +341,13 @@ Http is available as an injectable class, with methods to perform http requests.
 * [Practical Angular 2](https://leanpub.com/practical-angular-2) `Leanpub`
 * [Switching to Angular 2](https://www.packtpub.com/web-development/switching-angular-2) `Packt Publishing`
 * [Rangle's Angular 2 training](https://www.gitbook.com/book/rangle-io/ngcourse2/details) `Rangle.io`
-* [揭秘Angular 2](https://www.amazon.cn/%E5%9B%BE%E4%B9%A6/dp/B01NBOQCJW) `GF Securities`
+* [揭秘 Angular 2](https://www.amazon.cn/%E5%9B%BE%E4%B9%A6/dp/B01NBOQCJW) `GF Securities`
 * [Learn Angular 2](http://learnangular2.com/) `Ionic Team`
 * [Testing Angular Applications](https://www.manning.com/books/testing-angular-applications) `Manning Publications`
 * [Angular-Buch (German)](https://angular-buch.com/) `dpunkt.verlag`
 
 #### On-Site Training
+
 * [AngularClass](https://angularclass.com)
 * [Angular Boot Camp](https://angularbootcamp.com)
 * [thoughtram](http://thoughtram.io/training.html)
@@ -328,7 +360,9 @@ Http is available as an injectable class, with methods to perform http requests.
 * [Angular.Schule (in Germany)](https://angular.schule/)
 
 #### Approach and Explanation
+
 * Victor Savkin
+
   * [Dependency Injection in Angular 1 and Angular 2](https://vsavkin.com/dependency-injection-in-angular-1-and-angular-2-d69589979c18)
   * [Writing Angular in Typescript](https://vsavkin.com/writing-angular-2-in-typescript-1fa77c78d8e8)
   * [Angular Template Syntax](https://vsavkin.com/angular-2-template-syntax-5f2ee9f13c6a)
@@ -340,11 +374,13 @@ Http is available as an injectable class, with methods to perform http requests.
   * [Angular 2 Router](https://vsavkin.com/angular-2-router-d9e30599f9ea)
 
 * AngularClass
+
   * [Automated Angular 2 Conventions with Webpack](https://angularclass.com/blog/automated-angular-2-conventions-with-webpack/)
   * [Angular 2 for AngularJS deverlopers](https://angularclass.com/blog/angular-2-for-angularjs-developers/)
   * [Angular 2 for ReactJS deverlopers](https://angularclass.com/blog/angular-2-for-react-developers/)
 
 * thoughtram
+
   * [Developing a tabs component in Angular 2](https://blog.thoughtram.io/angular/2015/04/09/developing-a-tabs-component-in-angular-2.html)
   * [Developing a zippy component in Angular 2](https://blog.thoughtram.io/angular/2015/03/27/building-a-zippy-component-in-angular-2.html)
   * [Resolving Service Dependencies in Angular 2](https://blog.thoughtram.io/angular/2015/09/17/resolve-service-dependencies-in-angular-2.html)
@@ -361,9 +397,11 @@ Http is available as an injectable class, with methods to perform http requests.
   * [The difference between Annotations and Decorators](https://blog.thoughtram.io/angular/2015/05/03/the-difference-between-annotations-and-decorators.html)
 
 * Hristo Georgiev
+
   * [Debugging Angular 2 Applications](https://www.pluralsight.com/guides/front-end-javascript/debugging-angular-2-applications)
 
 * Helgevold Consulting
+
   * [Web Workers in Angular 2.0](http://www.syntaxsuccess.com/viewarticle/web-workers-in-angular-2.0)
   * [Creating a Virtualized Grid](http://www.syntaxsuccess.com/viewarticle/virtualized-spreadsheet-component-in-angular-2.0)
   * [Socket.io with Observables](http://www.syntaxsuccess.com/viewarticle/socket.io-with-rxjs-in-angular-2.0)
@@ -373,6 +411,7 @@ Http is available as an injectable class, with methods to perform http requests.
   * [Angular 4 with server side rendering (aka Angular Universal)](https://medium.com/burak-tasci/angular-4-with-server-side-rendering-aka-angular-universal-f6c228ded8b0)
 
 #### Integrations
+
 * [FalcorJS + Angular2 (Video)](https://www.youtube.com/watch?v=z8UgDZ4rXBU&feature=youtu.be)
 * [Angular2-Meteor](http://angular-meteor.com/angular2)
 * [nativescript-angular](https://github.com/NativeScript/nativescript-angular)
@@ -380,7 +419,12 @@ Http is available as an injectable class, with methods to perform http requests.
 * [GraphQL + Angular](https://github.com/apollographql/apollo-angular)
 
 #### Third Party Components
+
 * [Material 2](https://github.com/angular/material2) - Angular team's Material Design components built on top of Angular 2
+  [![GitHub stars](https://img.shields.io/github/stars/angular/material2.svg)](https://github.com/angular/material2)
+  [![GitHub last commit](https://img.shields.io/github/last-commit/google/skia.svg)](https://github.com/angular/material2)
+  [![GitHub commit activity the past week, 4 weeks, year](https://img.shields.io/github/commit-activity/y/eslint/eslint.svg)](https://github.com/angular/material2)
+
 * [NG ZORRO](https://github.com/NG-ZORRO/ng-zorro-antd) - An enterprise-class UI components based on Ant Design and Angular.
 * [Element Angular](https://github.com/eleme/element-angular) - Element Design components built on top of Angular 2
 * [Axponents: of Accessible Web Components (Dylan Barrell)](https://github.com/dylanb/Axponents/tree/master/angular2)
@@ -414,7 +458,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [ng2-sheet](https://github.com/lexikteam/ng2-sheet) Angular2 Components to add yours components inside a sheet window and repeatedly
 * [ng2-paginator](https://github.com/pleerock/ngx-paginator) Pagination control for angular2 and bootstrap 3
 * [fuel-ui](https://github.com/FuelInteractive/fuel-ui) Bootstrap 4 components and directives for use in Angular 2
-* [prime-ng](https://www.primefaces.org/primeng/)  Collection of rich UI components for Angular 2
+* [prime-ng](https://www.primefaces.org/primeng/) Collection of rich UI components for Angular 2
 * [ng2-ace](https://github.com/seiyria/ng2-ace) Ace editor directive made for Angular 2
 * [ng2-storage](https://github.com/seiyria/ng2-storage) A localStorage and sessionStorage wrapper written using ES6 Proxies for Angular 2
 * [ng2-fontawesome](https://github.com/seiyria/ng2-fontawesome) A small directive making font awesome even easier to use.
@@ -436,7 +480,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [Teradata covalent](https://github.com/Teradata/covalent/) - UI Platform built on @angular/material 2.0
 * [ng2-quill-editor](https://github.com/surmon-china/ngx-quill-editor) - Quill editor component for Angular2
 * [ngx-charts](https://github.com/swimlane/ngx-charts) - Declarative Charting Framework for Angular2 and beyond!
-* [ngx-datatable](https://github.com/swimlane/ngx-datatable)  A feature-rich yet lightweight data-table crafted for Angular2 and beyond!
+* [ngx-datatable](https://github.com/swimlane/ngx-datatable) A feature-rich yet lightweight data-table crafted for Angular2 and beyond!
 * [ngx-ui](https://github.com/swimlane/ngx-ui) - Style and Component Library for Angular2 and beyond!
 * [Cloudinary](https://github.com/cloudinary/cloudinary_angular/tree/angular_next) - Angular2 SDK for image and video management in the cloud
 * [angular2-simple-countdown](https://github.com/previousdeveloper/angular2-simple-countdown) - a simple countdown angular2 directive with multiple language
@@ -457,7 +501,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [ng2-archwizard](https://github.com/madoar/ng2-archwizard) - Wizard component for Angular 2
 * [ngx-popper](https://github.com/MrFrankel/ngx-popper) - Tooltip managment, wrapper for popper.js(https://popper.js.org/)
 * [ngx-avatar](https://github.com/HaithemMosbahi/ngx-avatar) - Avatar component that makes it possible to genearte / fetch avatar based on the information you have about the user.
-* [ngx-qrcode2](https://github.com/techiediaries/ngx-qrcode) - An Angular 4+ Component library for Generating QR (Quick Response ) Codes 
+* [ngx-qrcode2](https://github.com/techiediaries/ngx-qrcode) - An Angular 4+ Component library for Generating QR (Quick Response ) Codes
 * [ng2-permission](https://github.com/JavadRasouli/ng2-permission) - Fully featured permission based access control for your angular 4+ applications. This module inspired from [`angular-permission`](https://github.com/Narzerus/angular-permission).
 * [ng-s-resource](https://github.com/hiyali/ng-s-resource) - Simplify RESTful http resource generator for Angular 4+.
 * [ng-data-picker](https://github.com/hiyali/ng-data-picker) - 🏄🏼 A data picker based on Angular 4+ (like iOS native datetime picker)
@@ -474,9 +518,11 @@ Http is available as an injectable class, with methods to perform http requests.
 * [ngx-mapbox-gl](https://github.com/Wykks/ngx-mapbox-gl) - Angular binding of mapbox-gl-js
 
 #### Site Templates
+
 * [NG-Dashboard](https://github.com/YagoLopez/ng-dashboard) - Dashboard for Angular 4+. UI Components based on [Material Light](https://github.com/YagoLopez/material-light?ref=awesome-angular). Chart Component based on [MetricsGraficsJS](https://www.metricsgraphicsjs.org). Map Directive based on [LeafletJS](http://leafletjs.com). [DEMO ONLINE](http://yagolopez.js.org/ng-dashboard/dist/)
 
 #### Pipes
+
 * [fuel-ui](https://github.com/FuelInteractive/fuel-ui) OrderBy and Range pipes ported from Angular 1.x to Angular 2
 * [ngx-filter-pipe](https://github.com/VadimDez/ngx-filter-pipe) Pipe for filtering arrays
 * [ngx-pipes](https://github.com/danrevah/ngx-pipes) Bunch of useful pipes for Angular2 and beyond!
@@ -484,6 +530,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [angular2-camelcase](https://github.com/previousdeveloper/angular2-camelcase) Angular2 pipe to convert camelCase strings to human readable strings Edit
 
 #### Generators
+
 * Node.js
   * Slush
     * [TheVelourFog/slush-angular2](https://github.com/RyanMetin/slush-angular2)
@@ -501,7 +548,6 @@ Http is available as an injectable class, with methods to perform http requests.
 
 #### Documentation tools
 
-
 * [Storybook](https://github.com/storybooks/storybook) : "The UI development environment you'll love to use"
 
 * [Compodoc](https://github.com/compodoc/compodoc) : "The missing documentation tool for your Angular 2 application", integrate well with npm scripts
@@ -511,34 +557,40 @@ Http is available as an injectable class, with methods to perform http requests.
 * [NgModule-Viz](https://github.com/politie/ngmodule-viz) : Visualize the dependencies between the NgModules in your Angular 2+ application.
 
 #### TodoMVC
+
 * [Official Angular 2.0](http://todomvc.com/examples/angular2/)
 
 ---
 
 ### Universal Angular 2
+
 > Universal (isomorphic) javascript support for Angular 2
 
 #### Universal General Resources
+
 * [Universal Angular 2 Repository (GitHub)](https://github.com/angular/universal)
 
 #### Universal Seed Projects
+
 * [universal-starter](https://github.com/angular/universal-starter) - Angular 2 Universal starter kit by @Angular-Class
 * [ng-seed/universal](https://github.com/ng-seed/universal) - Seed project for Angular Universal apps featuring Server-Side Rendering (SSR), Webpack, dev/prod modes, DLLs, AoT compilation, HMR, SCSS compilation, lazy loading, config, cache, i18n, SEO, and TSLint/codelyzer by @fulls1z3
 
 ---
 
 ### Angular 2 in TypeScript
+
 > TypeScript lets you write JavaScript the way you really want to.
-TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
+> TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 
 #### TypeScript General Resources
+
 * [TypeScript](http://www.typescriptlang.org/) Official Website for TypeScript
 * [REPL](http://www.typescriptlang.org/play/) Official TypeScript REPL that runs entirely in your browser
 * [TypeScript Repository (GitHub)](https://github.com/Microsoft/TypeScript) Official GitHub Repo for TypeScript
 * [DefinitelyTyped Repository (GitHub)](https://github.com/DefinitelyTyped/DefinitelyTyped) The repository for high quality TypeScript type definitions.
 
-
 #### TypeScript Seed Projects
+
 * [Angular Seed](https://mgechev.github.io/angular-seed/) Seed project for Angular apps
 * [ng2-play](https://github.com/pkozlowski-opensource/ng2-play) A minimal Angular2 playground using TypeScript and SystemJS loader
 * [Angular Lab](https://github.com/rolandjitsu/angular-lab) A simple Angular 2+ setup using [Angular CLI](https://cli.angular.io), [TypeScript](http://www.typescriptlang.org), [Angular Flex Layout](https://github.com/angular/flex-layout), [Material 2](https://material.angular.io), [AOT](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html), and unit and e2e tests on [Travis CI](https://travis-ci.org) and [Saucelabs](https://saucelabs.com).
@@ -558,8 +610,8 @@ TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 * [Angular 2 Dashboard Starter](https://github.com/hasanhameed07/angular2-dashboard-starter) - Ready to use dashboard control panel seed project based on Angular 2 and AdminLTE bootstrap theme.
 * [ngx-admin](https://github.com/akveo/ngx-admin) - Admin template based on Nebular framework (Angular 4+, Bootstrap 4+)
 * [Angular 2 quickstart seed](https://github.com/valor-software/angular2-quickstart)
-* [Angular 2 full code coverage](https://github.com/danday74/angular2-coverage) - Solid tested SystemJS and gulp workflow ready for your code using Angular2 final release (2.1.0) .. Demonstrates unit 
- and full code coverage
+* [Angular 2 full code coverage](https://github.com/danday74/angular2-coverage) - Solid tested SystemJS and gulp workflow ready for your code using Angular2 final release (2.1.0) .. Demonstrates unit
+  and full code coverage
 * [Angular 2 webpack](https://github.com/michaelbazos/angular2-starter) - Tour of Heroes official typescript tutorial built with webpack
 * [ng2-boiler](https://github.com/amcdnl/ng2-boiler) - A bare-bones simple starter with Angular2, TypeScript and Webpack configured.
 * [Angular Webpack Starter](https://github.com/antonybudianto/angular-webpack-starter) - Angular Webpack Starter with AoT compilation, Lazy-loading, and Tree-shaking
@@ -573,36 +625,41 @@ TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 * [Angular5 + Firebase + Structure](https://github.com/naologic/angular5-starter) - Angular 5 + Firebase + a very good router/module structure to make it your own so easy
 * [**{{** add_your_repo **}}**](https://github.com/gdi2290/awesome-angular/edit/gh-pages/README.md)
 
-
 ---
 
 #### Ionic 2 in Angular 2
+
 > Ionic is the beautiful, open source front-end SDK for developing hybrid mobile apps with web technologies.
 
 * [Ionic Framework](http://ionicframework.com) Official Website for Ionic Framework
 * [Ionic Documentation](http://ionicframework.com/docs/) Official for Ionic Framework
 
 ##### Ionic 2 General Resources
+
 * [Ionic 2 Repository (GitHub)](https://github.com//ionic-team/ionic)
 * [Ionic 2 Awesome](https://github.com/candelibas/awesome-ionic)
 
 ---
 
 #### Angular 2 in Cordova
+
 Apache Cordova is a popular mobile application development framework using CSS3, HTML5, and JavaScript instead of relying on platform-specific APIs.
 
 * [Cordova Framework](https://cordova.apache.org/) Official Website for Apache Cordova
 * [Cordova Documentation](https://cordova.apache.org/docs/en/latest/) Official Documentation for Apache Cordova
 
 ##### Cordova Seed Projects
+
 * [Angular 2 Seed CLI Admin (Template)](https://github.com/jvitor83/angular-pwa-seed) Multi-platform Angular 2 project (Web/PWA, Mobile and Desktop) with Ionic 2 (and optionally Bootstrap).
 
 ---
 
 ### Angular 2 in Dart
+
 > Dart is an open-source, scalable programming language, with robust libraries and runtimes, for building web, server, and mobile apps.
 
 #### Dart General Resources
+
 * [Dart](https://www.dartlang.org/) Official Website for Dart
 * [Dartpad](https://dartpad.dartlang.org/) Dartpad lets play with Dart on-line, in a zero-install, zero configuration environment.
 * [Dart Organization (GitHub)](https://github.com/dart-lang) Official GitHub Organization for Dart
@@ -610,11 +667,12 @@ Apache Cordova is a popular mobile application development framework using CSS3,
 * [Dartisans](https://plus.google.com/communities/114566943291919232850) The Official Dart Google+ community
 * [Dart Slack Channel](https://dartlang-slack.herokuapp.com/) The Official Dart Slack channel.
 
-
 #### Dart Seed Projects
+
 * [Angular 2 Dart Quickstart](https://github.com/andresaraujo/ng2_dart_quickstart) A minimal quick start project.
 
 #### Dart Demo, Samples, and Examples
+
 * [Hackernews App](https://github.com/andresaraujo/ng2_hackernews) A HackerNews application made with Angular 2 for Dart
 * [Router Demo](https://github.com/andresaraujo/ng2_dart_router_demo) A basic example of Angular 2 router.
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
@@ -637,17 +695,21 @@ Apache Cordova is a popular mobile application development framework using CSS3,
 ---
 
 ### Angular 2 in Babel
+
 > The compiler for writing next generation JavaScript.
 
 #### Babel General Resources
+
 * [Babel](https://babeljs.io/) Official Website for Babel
 * [REPL](https://babeljs.io/repl/) Official Babel REPL that runs entirely in your browser
 * [Babel Repository (GitHub)](https://github.com/babel/babel) Official GitHub Repo for Babel
 
 #### Babel Angular 2 Online Playground
+
 * [Plunker: Angular 2 + Babel](http://plnkr.co/edit/PxCzCu?p=preview)
 
 #### Babel Seed Projects
+
 * [babel-angular2-app](https://github.com/shuhei/babel-angular2-app) A skeleton Angular 2 app built with [Babel](https://babeljs.io/) and [Browserify](http://browserify.org/).
 * [angular2-fullstack-starter](https://github.com/jgodi/angular2-fullstack-starter) A full stack skeleton Angular 2 app built with Webpack/Babel.
 * [angular2-es6-starter](https://github.com/blacksonic/angular2-babel-esnext-starter) A skeleton Angular 2 ES6 application built with Babel, Webpack, Gulp.
@@ -655,49 +717,59 @@ Apache Cordova is a popular mobile application development framework using CSS3,
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 #### Babel Demo, Samples, and Examples
+
 * [angular2-es6-todomvc](https://github.com/blacksonic/angular2-esnext-todomvc) Angular 2 TodoMVC implementation with ES6.
 * [ng1-ng2-webpack-lazy-uirouter](https://github.com/swimlane/ng1-ng4-webpack-lazy-uirouter) Hybrid lazy-loading Angular1 + Angular2 using UI-Router, Webpack2 and Babel.
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 #### Babel Plugins
+
 * [babel-preset-angular2](https://github.com/shuhei/babel-preset-angular2) Babel presets for Angular2
 * [babel-plugin-type-assertion](https://github.com/shuhei/babel-plugin-type-assertion) An experimental babel transformer plugin for rtts_assert
 
 ---
 
 ### Angular 2 in ES5
+
 > An ECMAScript language that includes structured, dynamic, functional, and prototype-based features.
 
 ##### ES5 General Resources
+
 * [**{{** help_add_resources **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 #### ES5 Seed Projects
+
 [angular2-es5-starter-kit](https://github.com/islam-muhammad/angular2-es5) Angular2 ES5 Starter Kit
 
 ---
 
 #### Meteor in Angular 2
+
 > Build Realtime Web and Mobile Apps With Angular and Meteor
 
 ##### Meteor General Resources
+
 * [Angular Meteor](http://angular-meteor.com/) Official Website for Angular Meteor
 * [Angular 2 Meteor](https://www.angular-meteor.com/angular2)
 
 #### Meteor Seed Projects
+
 * [Angular2 Meteor Seed](https://github.com/KyneSilverhide/angular2-meteor-seed)
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
-
 
 ---
 
 #### Angular 2 in NativeScript
+
 > Build truly native iOS, Android and Windows Phone apps with Javascript and CSS. Try NativeScript open-source framework for cross-platform development.
 
 ##### NativeScript General Resources
+
 * [NativeScript](https://www.nativescript.org/) Official Website for NativeScript
 * [Using NativeScript](http://www.syntaxsuccess.com/viewarticle/using-nativescript-with-angular-2.0)
 
 #### NativeScript Seed Projects
+
 * [sample-Angular2](https://github.com/NativeScript/sample-Angular2)
 * [angular2-seed-advanced](https://github.com/NathanWalker/angular-seed-advanced)
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
@@ -705,24 +777,30 @@ Apache Cordova is a popular mobile application development framework using CSS3,
 ---
 
 #### Angular 2 in React Native
+
 > React Native enables you to build world-class application experiences on native platforms using a consistent developer experience based on JavaScript
 
 ##### React Native General Resources
+
 * [React Native](https://facebook.github.io/react-native/) Official Website for React Native
 
 #### React Native Projects
+
 * [Angular 2 React Native Renderer (GitHub)](https://github.com/angular/react-native-renderer)
 
 #### React Native Seed Projects
+
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 ---
 
 ### Angular 2 in Haxe
+
 > Haxe is an open source toolkit based on a modern, high level, strictly typed programming language, a cross-compiler, a complete cross-platform standard library and ways to access each platform's native capabilities. General purpose language, with Haxe, you can easily build cross-platform tools targeting all the mainstream platforms natively. "Write once compile anywhere", with strong easily extendable macro system and powerfull, highly optimizing compiler with DCE (and f.e. using inline constructors). Can be used for server side rendering and in isomorphic way - possible to share the same source code compiling into client side in javascript and server side in pyhton (or java/php/node - can be choosen later/changed at scaling). Haxe code can contain (inline) any target language fragments (can be used to step by step porting), the externs mechanism provides access to the native APIs and libraries in a type-safe manner.
 > Server, client, mobile (Android and iOS at once), desktop, embedded (Raspbery, award winning TIVO set top boxes), Playstation ... all can be reached natively with much less typing, more error-proof, more stable and compile-time type checked code even for non type-safe targets (f.e. JavaScript, PHP)!
 
 ##### Haxe General Resources
+
 * [Haxe.org](http://haxe.org)
 * [Haxe on Wikipedia](https://en.wikipedia.org/wiki/Haxe)
 * [Haxe Playground ](https://try.haxe.org/)
@@ -737,43 +815,51 @@ Apache Cordova is a popular mobile application development framework using CSS3,
 * [**{{** help_add_resources **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 #### Haxe Seed Projects
+
 * [angular2haxe](https://github.com/nweedon/angular2haxe) Haxe Language Bindings for Angular 2
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 ---
 
 ### Angular 2 in Scala
+
 > General purpose language; multiparadigm (object-oriented, functional, concurrent elements); statically typed, type-safe; focus: Web services.
 
 ##### Scala General Resources
+
 * [**{{** help_add_resources **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 #### Scala Seed Projects
+
 * [play-angular2](https://github.com/gdi2290/play-angular2)
 * [**{{** add_your_repo **}}**](https://github.com/angularclass/awesome-angular/edit/gh-pages/README.md)
 
 ---
 
 ### Angular 2 components with Bit
+
 > Bit is an open source virtual repository (code base) built to make components easily manageable and usable across applications. You can quickly export any Angular component from any context while working on any project to a bit distributed Scope. Bit's reusbale component environment cuts the overhead of configuring build and test environments for exporting every new component. The Scope is a virtual component repository which stores, organizes, manages and tests your components. Once modeled on a Scope, your components can be easily found and used in any Angular application. Components can be organized together and still modified and used individually without pulling in entire libraries.
 
 ##### Bit Resources
+
 * [Bit](https://github.com/teambit/bit)
 * [Bit-Javascript](https://github.com/teambit/bit-javascript)
-* [bitsrc](https://bitsrc.io/) - Free community hub for sharing, managing and finding open source components. 
+* [bitsrc](https://bitsrc.io/) - Free community hub for sharing, managing and finding open source components.
 
 ---
 
 #### Security
+
 * [Angular.io Security Guide](https://angular.io/guide/security) - brief security guidance including Preventing cross-site scripting (XSS), Sanitization and Content security policy.
 * So you thought you were safe using AngularJS? Think again! [Slides](https://www.owasp.org/images/4/46/OWASPLondon20170727_AngularJS.pdf), [Video](https://www.youtube.com/watch?v=3vuLPzjc4RI) - Lewis Ardern speaking at OWASP London 2017
-##### Authentication
+  ##### Authentication
 * [Angular 2 with OpenID Connect Implicit Flow from Damien Bowden](https://damienbod.com/2016/03/02/angular2-openid-connect-implicit-flow-with-identityserver4/)
 * [Angular 2 bootstrap4 OAuth2 Webpack from Michael Oryl](https://github.com/michaeloryl/angular2-bootstrap4-oauth2-webpack)
 * [Angular 2 OAuth2 OIDC from Manfred Steyer](https://www.softwarearchitekt.at/post/2016/07/03/authentication-in-angular-2-with-oauth2-oidc-and-guards-for-the-newest-new-router-english-version.aspx)
 * [Angular 2 authentication sample from auth0-blog](https://github.com/auth0-blog/angular2-authentication-sample)
 
 #### NgRx
+
 * [Comprehensive Introduction to @ngrx/store](https://gist.github.com/btroncone/a6e4347326749f938510)
 * [Adding Redux With NgRx/store and Angular2 - Part 1](http://orizens.com/wp/topics/adding-redux-with-ngrxstore-to-angular-2-part-1/)
 * [Adding Redux with NgRx/store to Angular2 – Part 2 (Testing Reducers)](http://orizens.com/wp/topics/adding-redux-with-ngrxstore-to-angular2-part-2-testing-reducers/)
@@ -781,11 +867,11 @@ Apache Cordova is a popular mobile application development framework using CSS3,
 * [Angular 2, Ngrx/Store & Ngrx/Effects – Intro To Functional Approach For A Chain Of Actions](http://orizens.com/wp/topics/angular-2-ngrxstore-ngrxeffects-intro-to-functional-approach-for-a-chain-of-actions/)
 * [Making chained API Calls using @ngrx/Effects](https://gist.github.com/peterbsmith2/ce94c0a5ddceb99bab24a761731d1f07)
 
-___
+---
 
 enjoy — [**PatrickJS**](http://twitter.com/gdi2290?ref=awesome-angular)
 
-___
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Table of contents:
   * [On-Site Training](#on-site-training)
   * [Approach and Explanation](#approach-and-explanation)
   * [Integrations](#integrations)
-  * [Components](#components)
+  * [Third Party Components](#third-party-components)
   * [Site Templates](#site-templates)
   * [Generators](#generators)
   * [Documentation tools](#documentation-tools)
@@ -379,7 +379,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [react-native-renderer](https://github.com/angular/react-native-renderer)
 * [GraphQL + Angular](https://github.com/apollographql/apollo-angular)
 
-#### Components
+#### Third Party Components
 * [Material 2](https://github.com/angular/material2) - Angular team's Material Design components built on top of Angular 2
 * [NG ZORRO](https://github.com/NG-ZORRO/ng-zorro-antd) - An enterprise-class UI components based on Ant Design and Angular.
 * [Element Angular](https://github.com/eleme/element-angular) - Element Design components built on top of Angular 2


### PR DESCRIPTION
TOC entry "Components" linked to another header called "Components". I changed the name of the section "Components" from TOC to "Third Party Components".

i tried workarounds with invisible characters (also as unicode etc.) but github didnt recognize that