### PR TITLE
docs(lib): adds casl-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Http is available as an injectable class, with methods to perform http requests.
 * [ngx-avatar](https://github.com/HaithemMosbahi/ngx-avatar) - Avatar component that makes it possible to genearte / fetch avatar based on the information you have about the user.
 * [ngx-qrcode2](https://github.com/techiediaries/ngx-qrcode) - An Angular 4+ Component library for Generating QR (Quick Response ) Codes
 * [ng2-permission](https://github.com/JavadRasouli/ng2-permission) - Fully featured permission based access control for your angular 4+ applications. This module inspired from [`angular-permission`](https://github.com/Narzerus/angular-permission).
+* [casl-angular](https://github.com/stalniy/casl/tree/master/packages/casl-angular) - Module which integrates isomorphic  permissions management library [CASL](https://github.com/stalniy/casl) with Angular2+
 * [ng-s-resource](https://github.com/hiyali/ng-s-resource) - Simplify RESTful http resource generator for Angular 4+.
 * [ng-data-picker](https://github.com/hiyali/ng-data-picker) - 🏄🏼 A data picker based on Angular 4+ (like iOS native datetime picker)
 * [ngx-siema](https://github.com/lexzhukov/ngx-siema) - Lightweight and simple carousel with no dependencies.


### PR DESCRIPTION
I added a library which allows to integrate [CASL](https://github.com/stalniy/casl) (authorization library) with Angular 2+. There are also a lot of interesting stuff in documentation - https://stalniy.github.io/casl/ and [related articles on Medium](https://medium.com/@sergiy.stotskiy/latest). 

The library has been around for almost a year, I used it on several projects and believe it's a very good addition to this list.