### PR TITLE
feat(library): add ngx-scrolltop

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ The HttpClient offers a simplified client HTTP API for Angular applications that
 * [@ngx-context](https://github.com/ng-turkey/ngx-context) - Angular Context: Easy property binding for router outlet and nested component trees..
 * [@instechnologies/ng-rooster](https://github.com/insurance-technologies/ng-rooster) - Angular wrapper of roosterjs, a rich text editor
 * [Angular SizeObserver](https://gitlab.com/service-work/size-observer) - style DOM elements based on their display size (rather than browser screen size).
+* [ngx-scrolltop](https://github.com/bartholomej/ngx-scrolltop) - Lightweight, Material Design inspired **button for scroll-to-top** of the page. 🔼 _No dependencies. Pure Angular!_ (Compatibility: Angular 9, Ivy, Universal, `ng add`)
   
 #### Decorators
 * [segal-decorators](https://github.com/danrevah/segal-decorators) Bunch of useful decorators for the web!


### PR DESCRIPTION
Add **ngx-scrolltop** https://github.com/bartholomej/ngx-scrolltop
_Lightweight, Material Design inspired button for scroll-to-top of the page. No dependencies. Pure Angular!_