### PR TITLE
Remove ng2-markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,6 @@ The HttpClient offers a simplified client HTTP API for Angular applications that
 #### Viewers
 
 * [egjs-flicking](https://github.com/naver/egjs-flicking/tree/master/packages/ngx-flicking) - It's reliable, flexible and extendable carousel for Angular.
-* [ng2-markdown](https://github.com/evanplaice/ng2-markdown) Angular2 Markdown Web Component
 * [ng2-pdf-viewer](https://github.com/VadimDez/ng2-pdf-viewer) PDF viewer component
 * [ng2-safe-img](https://github.com/hyzhak/ng2-safe-img) Very tiny and safe img for Angular 2
 * [ngu-carousel](https://github.com/sheikalthaf/ngu-carousel) - Angular Universal carousel.


### PR DESCRIPTION
This Angular-specific component will be deleted in favor of using wc-markdown (ie framework-agnostic web component)