### PR TITLE
Add ckeditor in text editor components

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ The HttpClient offers a simplified client HTTP API for Angular applications that
 * [angular2-froala-wysiwyg](https://github.com/froala/angular-froala-wysiwyg) Angular 2 wrapper for Froala WYSIWYG HTML Editor
 * [ng2-ace](https://github.com/seiyria/ng2-ace) Ace editor directive made for Angular 2
 * [ng2-quill-editor](https://github.com/surmon-china/ngx-quill-editor) - Quill editor component for Angular2
+* [ckeditor](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/angular.html) - Ckeditor plugin for Angular2+
 
 
 #### File Upload


### PR DESCRIPTION
CKEditor is mainly used in the angular applications for the purpose of HTML text editor