### PR TITLE
Added link of Angular Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Table of contents:
 * [Angular Performance Checklist](https://github.com/mgechev/angular-performance-checklist)
 * [List of 100 Angular Interview questions and answers](https://github.com/sudheerj/angular-interview-questions)
 * [Angular References](https://ngrefs.com)
+* [Angular Developer Roadmap](https://roadmap.sh/angular)
 
 #### Features
 


### PR DESCRIPTION
Hi @PatrickJS,

I came across your repository [awesome-angular](https://github.com/PatrickJS/awesome-angular) and found it to be a valuable resource for Angular enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Angular Developer Roadmap"](https://roadmap.sh/angular). I took the initiative to submit a ["Pull Request"](https://github.com/PatrickJS/awesome-angular/pull/467) adding it in "Cheatsheet" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz