### PR TITLE
Remove dead links from onsite training section

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,11 +394,6 @@ The HttpClient offers a simplified client HTTP API for Angular applications that
 #### On-Site Training
 
 * [Angular Boot Camp](https://angularbootcamp.com)
-* [thoughtram](https://thoughtram.io/training.html)
-* [ng-book](https://www.ng-book.com/2/)
-* [Angular 2 Workshop](https://chariotsolutions.com/course/angular-workshop-fundamentals-architecture/)
-* [Web Age Solutions](https://www.webagesolutions.com/courses/WA2533-introduction-to-angular-2-programming)
-* [Letsboot.com](https://www.letsboot.com/angular-2-in-house-training-support)
 * [Angular.Schule (in Germany)](https://angular.schule/)
 * [Angular.DE (Germany)](https://angular.de/schulungen/angular-intensiv/)
 * [Workshops.DE (Germany)](https://workshops.de/seminare-schulungen-kurse/angular-typescript/)


### PR DESCRIPTION
ng-book is not a dead link but it is from angular 11 and it has no business being in the onsite training section.  

thoughtram just closed down.  

I know to add one PR per change, but to update this repo to a relevant state,  I may focus on a section at a time.  