### PR TITLE
refactor: heading paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 # Awesome Angular [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-Awesome list of [Angular](https://angular.io/) seed repos, starters, boilerplates, examples, tutorials, components, modules, videos, and anything else in the Angular ecosystem. [View as github page.](https://PatrickJS.github.io/awesome-angular/).
-
-> If you're looking for AngularJS (version 1.x.x) please visit https://github.com/gianarb/awesome-angularjs
+This is the original Awesome list of the Angular2 framework, today known as just [Angular] (https://angular.io/). This repository contains intriguing libraries and repos in the Angular ecosystem for both inexperienced and seasoned developers.
 
 ##### Current Angular version:
 


### PR DESCRIPTION
Remove the AngularJS stuff as this makes the repo look outdated.  The GitHub pages link is ancient and not reflecting the correct state of the page now.  Also, I find it weird that the main branch is named `gh-pages`.    