### PR TITLE
docs: add built with angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [Top rated Angular stackoverflow questions Dashboard](https://dashboard.nbshare.io/apps/stackoverflow/top-angular-questions/)
 * [angular-logos](https://github.com/maartentibau/angular-logos) - Repo is dedicated to collecting all the different kinds of Angular badges and logos.
 * [made with angular](https://github.com/madewithangular/madewithangular.github.io) - A showcase of web apps built with Angular.  
-* [built with analog](https://github.com/TechShowcase/builtwithanalog) - Showcase and market your AnalogJS apps.
+* [built with angular](https://builtwithangular.dev/) - Discover apps of all sizes, including Open Source and Indie developer projects.
 * [angular.love](https://angular.love/) - Polish community for Angular fans.
 * [angular hub](https://github.com/angular-sanctuary/angular-hub) - Curated list of Angular events and communities.
 * [angular space](https://www.angularspace.com/) - Your Hub for Learning and Growing as an Angular Developer.


### PR DESCRIPTION
Built with Analog was deprecated and essentially replaced with builtwithangular.