### PR TITLE
docs(material): add angular-ui-plusify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1875,6 +1875,7 @@ to simplify usage and allow quick customization.
 
 ##### Material Based
 
+* [angular-ui-plusify](https://github.com/RockyCott/angular-ui-plusify) - It currently includes a Datetime Picker and the new Markdown Editor components — with plans to continue growing into a comprehensive UI toolkit for Angular developers.
 * [MDBootstrap](https://github.com/mdbootstrap/mdb-angular-ui-kit) - Bootstrap 5 & Angular 17 UI KIT - 700+ components, MIT license, simple installation.
 * [Angular Material](https://material.angular.io/) - Material Design components for Angular.
 * [Covalent](https://github.com/Teradata/covalent/) - Teradata UI Platform built on Angular Material.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry for "angular-ui-plusify" under the "Material Based" UI Libraries section, highlighting its Datetime Picker and Markdown Editor components for Angular developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->