### PR TITLE
docs(external): add ngx-signalr-websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -2053,6 +2053,7 @@ for the creation of web applications developed with Angular.
 * [angular-rsocket](https://github.com/saleweaver/angular-rsocket) - This service allows you to easily connect to an [RSocket](https://rsocket.io/) server, handle streams and messages, and manage authentication tokens flexibly via a token provider.
 * [Bit](https://bit.dev/docs/angular-introduction/) -  Leverage Bit to build composable software.
 * [angular-twitter-timeline](https://github.com/mustafaer/angular-twitter-timeline) - Angular Public Twitter Timeline Widget.
+* [ngx-signalr-websocket](https://github.com/yurivoronin/ngx-signalr-websocket) - A lightweight ASP.NET SignalR client for Angular.
 
 ### Wrappers
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "ngx-signalr-websocket" as a new entry under "External Integration" in the "Framework Interoperability" section of the README, highlighting it as a lightweight ASP.NET SignalR client for Angular.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->