### PR TITLE
docs(other-state): update signaltree url and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,7 +932,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ng-simple-state-management](https://github.com/LionMarc/ng-simple-state-management) - Simple state management implementation for Angular applications. This project provides several libraries for additional functionality.
 * [ngx-statewise](https://github.com/Pierre-MarieMarchio/ngx-statewise) - A state management solution for Angular applications, offering a lighter and easier-to-use alternative to libraries like NgRx or NGXS, while maintaining a clear and predictable architecture for managing your application's state.
 * [fsm-state-manager](https://github.com/NikitaTopchii/fsm-state-manager) - A simple, flexible and strongly-typed finite state machine manager for managing state transitions in Angular or any TypeScript-based application.
-* [signal-tree](https://github.com/JBorgia/signal-tree) - An Angular 16+ store built around signals that focuses on simplicity.
+* [signaltree](https://github.com/JBorgia/signaltree) - A powerful, type-safe, modular signal-based state management solution for Angular applications.
 
 ## Testing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README “Other State Libraries” entry: replaced “signal-tree” with “signaltree” and corrected the link to JBorgia/signaltree.
  - Revised the library description to: “A powerful, type-safe, modular signal-based state management solution for Angular applications.”
  - Users will see the correct repository link and an updated description in the public library listing.
  - No code or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->