### PR TITLE
docs(layout): add ngx-zoomable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1541,6 +1541,7 @@ to simplify usage and allow quick customization.
 * [ngx-flex-layout](https://github.com/jtc10005/ngx-flex-layout) - Port of [@angular/flex-layout](https://github.com/angular/flex-layout) to provide support after EOL.
 * [ng-polymorpheus](https://github.com/taiga-family/ng-polymorpheus) - Polymorpheus is a tiny library for polymorphic templates in Angular.
 * [gui](https://github.com/acrodata/gui) - JSON powered GUI for configurable panels.
+* [ngx-zoomable](https://github.com/json-k/ngx-zoomable) - A zoomable, pannable container component for Angular applications.
 
 ### Loaders
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README entry for ngx-zoomable in the Layout Components section, highlighting it as a zoomable, pannable container for Angular applications and linking to the project page.
  * Improved discoverability and categorization of layout utilities by including a clear, concise description.
  * Documentation-only update with no impact on application code, behavior, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->