### PR TITLE
docs(i18n): add ngx-translate-phraseapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [@transifex/angular](https://github.com/transifex/transifex-javascript/tree/master/packages/angular/projects/tx-native-angular-sdk) - You can easily localize Angular components using the [@transifex/angular](https://www.npmjs.com/package/@transifex/angular) library extension. This library extends the functionality of [Transifex Native JavaScript SDK](https://developers.transifex.com/docs/javascript-sdk).
 * [transloco](https://github.com/jsverse/transloco) - The internationalization (i18n) library for Angular.
 * [transloco-keys-manager](https://github.com/jsverse/transloco-keys-manager) - Tools to help reduce monotonous work.
+* [ngx-translate-phraseapp](https://github.com/phrase/ngx-translate-phraseapp) - The official library for integrating [Phrase Strings In-Context Editor](https://support.phrase.com/hc/articles/5784095916188-In-Context-Editor-Strings) with `ngx-translate` in your Angular application.
 
 ### Performance
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Third Party Components entry: ngx-translate-phraseapp, describing Phrase Strings In-Context Editor integration with ngx-translate for Angular.
  * Enhances discoverability of i18n integration options for Angular projects.
  * Provides clearer guidance on available tooling for in-context translation workflows.
  * Positioned near related entries to maintain logical organization.
  * No code or runtime behavior changes; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->