### PR TITLE
docs(cli): add ng new command generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [rafacli](https://github.com/rafa00716/rafacli) - A command-line tool designed to generate authentication and CRUD modules (and more soon) for NestJS and Angular applications. It streamlines the development process by automating boilerplate code creation, reducing repetitive tasks, and ensuring consistency across projects.
 * [ngx-crafter](https://github.com/ErwanHeschung/ngx-crafter) - A powerful CLI tool that helps you craft Angular projects with pre-configured folder structures and essential packages.
 * [angular-v20-bulk-file-refactor](https://github.com/esteecodes/angular-v20-bulk-file-refactor) - A CLI tool to automate file renaming and content refactoring to match Angular 20 conventions.
+* [ng new command generator](https://ng.gridatek.com/) - Generate optimized `ng new` commands.
 
 ### Deployment
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new bullet under “Current Angular version” pointing to the ng new command generator, enabling users to generate optimized ng new commands via the provided link.
  * Content-only update; no changes to application behavior or logic.
  * Improves clarity of setup resources by highlighting an external tool for streamlined project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->