### PR TITLE
docs(templates): add free-angular-tailwind-dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [spartan-stack-starter](https://github.com/thatsamsonkid/spartan-stack-starter) - An Opinionated Template Project Starter using Spartan Stack.
 * [jet](https://github.com/karmasakshi/jet) - Angular starter-kit for building quality web apps fast.
 * [serene](https://github.com/ClaudioAlcantaraR/serene) - A modern starter-kit for full-stack web development using Spring Boot and Angular. Inspired by Laravel Breeze, it provides a clean, secure, and minimalist foundation.
+* [free-angular-tailwind-dashboard](https://github.com/TailAdmin/free-angular-tailwind-dashboard) - Free, open-source Angular + Tailwind CSS admin dashboard with essential UI components and pre-built pages for a sleek, modern interface.
 
 ### Paid Templates
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “free-angular-tailwind-dashboard” entry to the “Current Angular version” list and the “Free Templates” section in the Site Templates area.
  * Included the same URL and description highlighting an Angular + Tailwind CSS admin dashboard with essential UI components and pre‑built pages.
  * No functional changes or public API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->