### PR TITLE
docs(newsletters): add angular-digest and reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,11 +260,12 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 ### Newsletters
 
 * [angular addicts](https://www.angularaddicts.com/)
-* [weekly angular](https://prodigious-knitter-4508.ck.page/subscribe)
+* [angular digest](https://geromegrignon.substack.com/)
 * [angular weekly](https://angularweekly.substack.com/)
-* [practical-angular-newsletter](https://angularmentor.io/practical-angular-newsletter)
 * [danywalls](https://www.danywalls.com/newsletter)
+* [practical-angular-newsletter](https://angularmentor.io/practical-angular-newsletter)
 * [ultimate courses](https://ultimatecourses.com/newsletter)
+* [weekly angular](https://prodigious-knitter-4508.kit.com/subscribe)
 
 ### Podcasts
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Newsletters section:
    * Replaced “weekly angular” with “Angular Digest (Substack)” while retaining “Angular Weekly.”
    * Reordered entries: moved “Practical Angular Newsletter” to follow “danywalls.”
    * Added a new “Weekly Angular” entry linking to a kit.com subscription at the end.
    * All other newsletter entries remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->