### PR TITLE
docs(templates): add hanko-angular-express-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [jet](https://github.com/karmasakshi/jet) - Angular starter-kit for building quality web apps fast.
 * [serene](https://github.com/ClaudioAlcantaraR/serene) - A modern starter-kit for full-stack web development using Spring Boot and Angular. Inspired by Laravel Breeze, it provides a clean, secure, and minimalist foundation.
 * [free-angular-tailwind-dashboard](https://github.com/TailAdmin/free-angular-tailwind-dashboard) - Free, open-source Angular + Tailwind CSS admin dashboard with essential UI components and pre-built pages for a sleek, modern interface.
+* [hanko-angular-express-starter](https://github.com/teamhanko/hanko-angular-express-starter) - This repo demonstrates how to integrate Hanko with an Angular application for authentication and user management.
 
 ### Paid Templates
 

--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [jet](https://github.com/karmasakshi/jet) - Angular starter-kit for building quality web apps fast.
 * [serene](https://github.com/ClaudioAlcantaraR/serene) - A modern starter-kit for full-stack web development using Spring Boot and Angular. Inspired by Laravel Breeze, it provides a clean, secure, and minimalist foundation.
 * [free-angular-tailwind-dashboard](https://github.com/TailAdmin/free-angular-tailwind-dashboard) - Free, open-source Angular + Tailwind CSS admin dashboard with essential UI components and pre-built pages for a sleek, modern interface.
-* [hanko-angular-express-starter](https://github.com/teamhanko/hanko-angular-express-starter) - This repo demonstrates how to integrate Hanko with an Angular application for authentication and user management.
+* [hanko-angular-express-starter](https://github.com/teamhanko/hanko-angular-express-starter) - Starter integrating Hanko authentication with Angular and Express.
 
 ### Paid Templates
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the hanko-angular-express-starter to two Free Templates lists under Site Templates to improve discoverability.
  * Clarifies Angular + Express starter for Hanko authentication and user management.
  * Content-only update; no functional or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->