### PR TITLE
docs(yt): add daniil rabizo

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [JSgigs](https://www.youtube.com/@jsgigs4909)
 * [Kobi Hari](https://www.youtube.com/@kobihari)
 * [Programming Practicals](https://www.youtube.com/@programmingpracticals)
+* [Daniil Rabizo](https://www.youtube.com/@daniilrabizo)
 * [StartupAngular](https://www.youtube.com/@StartupAngular) - In Japanese.
 * [Code with Keys](https://www.youtube.com/@codewithkeys) - In Persian.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new bullet for Daniil Rabizo with a YouTube link in the README’s YouTube Channels section, positioned after Programming Practicals.
  * Content-only documentation update; no code or behavior changes.
  * The curated list now includes this channel in the primary README.
  * No build or runtime impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->