### PR TITLE
docs(bootstrap ui): add ng-bootstrap-addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1888,7 +1888,7 @@ to simplify usage and allow quick customization.
 * [angular-bootstrap-md](https://mdbootstrap.com/docs/angular/) - Material Design
 for Bootstrap 5 & Angular 17.
 * [ng-bootstrap](https://ng-bootstrap.github.io) - Angular widgets built from the ground up using only Bootstrap 5 CSS with APIs designed for the Angular ecosystem.
-* [ng-bootstrap-addons](https://github.com/mikaelbotassi/ng-bootstrap-addons) - Project to add components that are not available in `ng-bootstrap`, such as input fields.
+* [ng-bootstrap-addons](https://github.com/mikaelbotassi/ng-bootstrap-addons) - Adds UI components not available in `ng-bootstrap` (e.g., input/form controls).
 * [ngx-bootstrap](https://github.com/valor-software/ngx-bootstrap) - Fast and reliable Bootstrap widgets in Angular (supports Ivy engine).
 * [design-angular-kit](https://github.com/italia/design-angular-kit) - A toolkit based on Bootstrap Italia
 for the creation of web applications developed with Angular.

--- a/README.md
+++ b/README.md
@@ -1888,6 +1888,7 @@ to simplify usage and allow quick customization.
 * [angular-bootstrap-md](https://mdbootstrap.com/docs/angular/) - Material Design
 for Bootstrap 5 & Angular 17.
 * [ng-bootstrap](https://ng-bootstrap.github.io) - Angular widgets built from the ground up using only Bootstrap 5 CSS with APIs designed for the Angular ecosystem.
+* [ng-bootstrap-addons](https://github.com/mikaelbotassi/ng-bootstrap-addons) - Project to add components that are not available in `ng-bootstrap`, such as input fields.
 * [ngx-bootstrap](https://github.com/valor-software/ngx-bootstrap) - Fast and reliable Bootstrap widgets in Angular (supports Ivy engine).
 * [design-angular-kit](https://github.com/italia/design-angular-kit) - A toolkit based on Bootstrap Italia
 for the creation of web applications developed with Angular.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry under “UI Libraries built on Bootstrap” for ng-bootstrap-addons, including a link and description highlighting supplemental components (e.g., input fields) not available in ng-bootstrap.
  * Improves discoverability of extended Bootstrap-based Angular component options for users.
  * No code or public API changes; installation and usage remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->