### PR TITLE
docs(pipes): add ngx-highlight-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1740,6 +1740,7 @@ to simplify usage and allow quick customization.
 * [ngx-pipe-lib](https://github.com/mofirojean/ngx-pipe-lib) - Common Angular pipe examples for your day to day tasks.
 * [memoize-pipe](https://github.com/ngx-rock/memoize-pipe) - A universal pipe for memoizing computations in Angular templates.
 * [ngx-number-to-words](https://www.npmjs.com/package/ngx-number-to-words) - An Angular library that provides a simple and effective pipe to convert numbers into their respective word representations. This is particularly useful for applications that need to display numbers in words, such as invoices, reports, or financial applications.
+* [ngx-highlight-text](https://github.com/ultrasonicsoft/ngx-highlight-text) - Angular pipe that highlights a selected word in the HTML markup.
 
 ### Printing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Expanded README Pipes section to include two entries for ngx-highlight-text, describing Angular pipes that highlight a selected word in HTML markup.
  * Improves discoverability and guidance for highlighting text in templates; entries appear in two relevant spots within the list for easier navigation. No code or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->