### PR TITLE
docs(forms): add lite-form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1415,6 +1415,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-formidable](https://github.com/Cynthion/ngx-formidable) - A powerful Angular component library for building rich, validated forms.
 * [piying-view](https://github.com/piying-org/piying-view) - A strongly typed frontend form solution; an alternative to `ngx-formly` and Angular's official form framework.
 * [ngx-form-m3](https://github.com/webilix/ngx-form-m3) - Persian form library for Angular and Material 3.
+* [lite-form](https://github.com/liangk/lite-form) - A comprehensive Angular library that provides lightweight, customizable form components with built-in validation, styling, and animations.
 
 ### Form Controls
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include lite-form in the Form Libraries list, giving users another lightweight Angular form option to evaluate.
  * Improves discoverability of ecosystem alternatives with a brief description and link.
  * Ideal for teams seeking minimal footprint or simpler form handling.
  * No functional changes; APIs remain unchanged.
  * No configuration updates or migrations required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->