### PR TITLE
docs(editors): add angular-json-tree-editor-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,6 +1353,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 
 ### Editor Components
 
+* [Angular-JSON-Tree-Editor-Component](https://github.com/stefonalfaro/Angular-JSON-Tree-Editor-Component) - Angular JSON Tree Editor Component that actually works.
 * [acrodata/code-editor](https://github.com/acrodata/code-editor) - CodeMirror 6 wrapper for Angular.
 * [angular2-froala-wysiwyg](https://github.com/froala/angular-froala-wysiwyg) - Angular 2 wrapper for Froala WYSIWYG HTML Editor.
 * [ckeditor](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/angular.html) - Ckeditor plugin for Angular2+.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Editor Components section by adding an entry for an Angular JSON Tree Editor component, including a link and brief description to help users discover relevant editor integrations.
  * Clarifies available editor options without altering app behavior.
  * No changes to functionality; this update is purely informational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->