### PR TITLE
docs(other-state): add usm

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [angulator](https://github.com/angulator-dev/angulator) - A lightweight Angular [mediator](https://refactoring.guru/design-patterns/mediator) library, designed to simplify communication between different parts of your application using a request/response and notification/handler pattern.
 * [ngx-query](https://github.com/CoreSyncHub/ngx-query) - A lightweight, observable-based query library that helps you manage server state, caching, and synchronization between your backend and UI.
 * [@tanstack/angular-db](https://github.com/TanStack/db/tree/main/packages/angular-db) - Angular hooks for TanStack DB, a reactive client store that lets you build fast, sync‑driven apps with a backend‑agnostic real‑time data layer.
+* [usm](https://github.com/unadlib/usm) - A modular state management library compatible with Angular.
 
 ## Testing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added “usm” as a resource under Angular Official Resources.
  - Added “usm” under State Management > Other State Libraries for easier discovery.
  - Ensured consistent formatting, ordering, and styling with neighboring entries for readability.
  - This is a purely additive update with no changes to existing content.
  - Improves documentation completeness by listing “usm” in both relevant sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->