### PR TITLE
docs(mixed): add farfadev/ngx-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1742,6 +1742,7 @@ to simplify usage and allow quick customization.
 * [xprng](https://github.com/ziv/xprng) - Micro packages of simple and smart components for Angular.
 * [ngx-primeng-toolkit](https://github.com/saiful-70/ngx-primeng-toolkit) - A comprehensive TypeScript utility library for Angular component state management, including PrimeNG table helpers, `ng-select` integration, data storage, and HTTP caching utilities with NgRx signals.
 * [@ibenvandeveire opensource](https://github.com/IbenTesara/opensource) - A monorepo hosting multiple packages—both Angular and non-Angular—developed and maintained by [Iben Van de Veire](https://github.com/IbenTesara).
+* [@farfadev/ngx-lib](https://github.com/farfadev/ngx-lib) - A repository of Angular libraries—including components, services, and more—commonly used across [Farfadev](https://github.com/farfadev) applications, but available for use in any other app.
 
 ### Modals
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added @farfadev/ngx-lib to the Angular third-party libraries list, indicating it as a reusable Angular library available for general use.
  * Improves discoverability of recommended ecosystem libraries for developers evaluating integrations.
  * No functional changes, configuration updates, or API adjustments were introduced in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->