### PR TITLE
docs: add ngx-mat-errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1540,6 +1540,7 @@ to simplify usage and allow quick customization.
 * [angular-password-checker](https://github.com/akehir/angular-password-checker) - Protect your users from re-using a password known to be hacked with this simple Angular directive.
 * [translation-validation](https://github.com/RiskChallenger/translation-validation) - Automatic validation messages for Angular forms in any language.
 * [polish-validators](https://github.com/joker876/polish-validators) - A validation library designed for Polish-specific formats, also available as an Angular wrapper via [ngx-polish-validators](https://www.npmjs.com/package/ngx-polish-validators).
+* [ngx-mat-errors](https://github.com/Totati/ngx-mat-errors) - Offers a simple and adaptable approach to presenting error messages within a `MatFormField`.
 
 ### Icons
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “ngx-mat-errors” to the Angular Third-Party Components/Icons list, highlighting it as a simple, flexible way to display validation messages within MatFormField.
  * Improves discoverability of a helpful UI utility for error handling in Angular Material forms.
  * No runtime or behavioral changes; this is a content-only update to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->