### PR TITLE
docs: add ngx-ratio-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1589,6 +1589,7 @@ to simplify usage and allow quick customization.
 * [ngx-img-cropper](https://github.com/web-dave/ngx-img-cropper) - Image cropping tool for Angular.
 * [ngx-lightbox](https://github.com/jjmhalew/ngx-lightbox) - A [lightbox2](https://github.com/lokesh/lightbox2) implementation port to use with Angular >= 18 (zoneless).
 * [ngx-pinch-zoom](https://github.com/medDV-GmbH/ngx-pinch-zoom) - This module enables image zooming and positioning through touch screen gestures.
+* [ngx-ratio-image](https://github.com/gerd-siebert/ngx-ratio-image) - An Angular library to show an image with variable ratio in container with a fixed ratio.
 * [ngx-smart-cropper](https://github.com/kurti-vdb/ngx-smart-cropper) - Angular standalone component that allows users to upload, crop, and resize images with ease. It provides intuitive drag-and-resize functionality, grid overlays, and supports various aspect ratios and output formats.
 * [unpic](https://unpic.pics/img/angular/) - Angular directive for responsive, high-performance images. Generates a responsive `<img>` tag that follows best practices, with the correct srcset, sizes and styles. Detects image URLs from most image CDNs and CMSs and can resize images with no build step.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include the ngx-ratio-image Angular library, described as displaying images with variable ratios within fixed-ratio containers.
  * Improves discoverability of available libraries and clarifies capabilities.
  * Existing entries and structure remain unchanged.
  * No application code changed; this is a docs-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->