### PR TITLE
docs: add chat-widget-adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2233,7 +2233,7 @@ for the creation of web applications developed with Angular.
 
 * [angular-email-editor](https://github.com/unlayer/angular-email-editor) - Drag-n-drop email editor by [Unlayer](https://unlayer.com/embed) as an Angular wrapper component.
 * [angular-three](https://github.com/angular-threejs/angular-three) - Angular Renderer for [THREE.js](https://github.com/mrdoob/three.js).
-* [chat-widget-adapters](https://github.com/livechat/chat-widget-adapters) - This project provides a library for integrating the [LiveChat](https://developers.livechat.com/) Chat Widget into Angular applications, leveraging the Chat Widget JavaScript API for seamless adaptation.
+* [chat-widget-adapters](https://github.com/livechat/chat-widget-adapters) - Angular wrapper for the [LiveChat](https://developers.livechat.com/) Chat Widget (JavaScript API).
 * [ckeditor5-angular](https://github.com/ckeditor/ckeditor5-angular) - An official CKEditor 5 rich text editor component for Angular 2+.
 * [ckeditor4-angular](https://github.com/ckeditor/ckeditor4-angular) - An official CKEditor 4 rich text editor component for Angular 2+.
 * [cytoscape-angular](https://github.com/michaelbushe/cytoscape-angular) - A production-ready Angular library providing sophisticated graph visualization capabilities using [Cytoscape.js](https://js.cytoscape.org/).

--- a/README.md
+++ b/README.md
@@ -2233,6 +2233,7 @@ for the creation of web applications developed with Angular.
 
 * [angular-email-editor](https://github.com/unlayer/angular-email-editor) - Drag-n-drop email editor by [Unlayer](https://unlayer.com/embed) as an Angular wrapper component.
 * [angular-three](https://github.com/angular-threejs/angular-three) - Angular Renderer for [THREE.js](https://github.com/mrdoob/three.js).
+* [chat-widget-adapters](https://github.com/livechat/chat-widget-adapters) - This project provides a library for integrating the [LiveChat](https://developers.livechat.com/) Chat Widget into Angular applications, leveraging the Chat Widget JavaScript API for seamless adaptation.
 * [ckeditor5-angular](https://github.com/ckeditor/ckeditor5-angular) - An official CKEditor 5 rich text editor component for Angular 2+.
 * [ckeditor4-angular](https://github.com/ckeditor/ckeditor4-angular) - An official CKEditor 4 rich text editor component for Angular 2+.
 * [cytoscape-angular](https://github.com/michaelbushe/cytoscape-angular) - A production-ready Angular library providing sophisticated graph visualization capabilities using [Cytoscape.js](https://js.cytoscape.org/).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "chat-widget-adapters" entry to the Wrappers section (appears in two places). Describes a library for wrapping LiveChat's Chat Widget (JavaScript API) for Angular integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->