### PR TITLE
docs: add ngx-rumbletalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1740,7 +1740,7 @@ to simplify usage and allow quick customization.
 * [ngx-lite-video-v2](https://github.com/KSmp/ngx-lite-video) - An updated fork of [ngx-lite-video](https://github.com/karim-mamdouh/ngx-lite-video), an Angular package that provides lazy loading capabilities for embedded iframes from popular video-sharing platforms like YouTube and Vimeo.
 * [ngx-user-camera](https://codeberg.org/tomaszatoo/ngx-user-camera) - A modern Angular 20+ component for accessing user cameras, supporting front/back (user/environment) switching, optional canvas rendering, and reactive signals — fully zoneless.
 * [rm-ng-video-player](https://github.com/malikrajat/rm-ng-video-player-main) - An advanced, feature-rich Angular video player with YouTube-style controls and Apple-inspired glassmorphism design.
-* [ngx-rumbletalk](https://github.com/RumbleTalk/ngx-rumbletalk) - An angular library for [Rumbletalk](https://rumbletalk.com/) group chats.
+* [ngx-rumbletalk](https://github.com/RumbleTalk/ngx-rumbletalk) - An Angular library for [Rumbletalk](https://rumbletalk.com/) group chats.
 
 ### Mixed Utilities
 

--- a/README.md
+++ b/README.md
@@ -1740,6 +1740,7 @@ to simplify usage and allow quick customization.
 * [ngx-lite-video-v2](https://github.com/KSmp/ngx-lite-video) - An updated fork of [ngx-lite-video](https://github.com/karim-mamdouh/ngx-lite-video), an Angular package that provides lazy loading capabilities for embedded iframes from popular video-sharing platforms like YouTube and Vimeo.
 * [ngx-user-camera](https://codeberg.org/tomaszatoo/ngx-user-camera) - A modern Angular 20+ component for accessing user cameras, supporting front/back (user/environment) switching, optional canvas rendering, and reactive signals — fully zoneless.
 * [rm-ng-video-player](https://github.com/malikrajat/rm-ng-video-player-main) - An advanced, feature-rich Angular video player with YouTube-style controls and Apple-inspired glassmorphism design.
+* [ngx-rumbletalk](https://github.com/RumbleTalk/ngx-rumbletalk) - An angular library for [Rumbletalk](https://rumbletalk.com/) group chats.
 
 ### Mixed Utilities
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "ngx-rumbletalk" to the Mixed Utilities list in the README, describing it as an Angular library for RumbleTalk group chats and linking to the project. This is a documentation-only update and does not change runtime behavior, logic, or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->