### PR TITLE
Add ar-virtual-scroll to Scroll section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1916,8 +1916,7 @@ to simplify usage and allow quick customization.
 * [ng-virtual-list](https://github.com/djonnyx/ng-virtual-list) - Maximum performance for extremely large lists. It is based on algorithms for virtualization of screen objects.
 * [ngx-horizontal-menu-scroll](https://github.com/isahohieku/ngx-horizontal-menu-scroll) - A lightweight, customizable Angular library for creating beautiful horizontal scrolling menus with smooth navigation controls.
 * [usal](https://github.com/italoalmeida0/usal) - Framework agnostic ultimate scroll animation library.
-* [ar-virtual-scroll](https://github.com/artomenwork/ar-virtual-scroll) — Lightweight Angular virtual scroll with automatic dynamic height measurement. Ideal for chats, message feeds and variable-height lists. Better alternative to Angular CDK virtual scroll when dynamic heights are required.
-
+* [ar-virtual-scroll](https://github.com/artomenwork/ar-virtual-scroll) - Lightweight Angular virtual scroll with automatic dynamic height measurement. Ideal for chats, message feeds, and variable-height lists. Better alternative to Angular CDK virtual scroll when dynamic heights are required.
 ### Storage
 
 * [rxdb](https://rxdb.info/) - An abstraction layer for [IndexedDB](https://rxdb.info/articles/angular-indexeddb.html).

--- a/README.md
+++ b/README.md
@@ -1917,6 +1917,7 @@ to simplify usage and allow quick customization.
 * [ngx-horizontal-menu-scroll](https://github.com/isahohieku/ngx-horizontal-menu-scroll) - A lightweight, customizable Angular library for creating beautiful horizontal scrolling menus with smooth navigation controls.
 * [usal](https://github.com/italoalmeida0/usal) - Framework agnostic ultimate scroll animation library.
 * [ar-virtual-scroll](https://github.com/artomenwork/ar-virtual-scroll) - Lightweight Angular virtual scroll with automatic dynamic height measurement. Ideal for chats, message feeds, and variable-height lists. Better alternative to Angular CDK virtual scroll when dynamic heights are required.
+
 ### Storage
 
 * [rxdb](https://rxdb.info/) - An abstraction layer for [IndexedDB](https://rxdb.info/articles/angular-indexeddb.html).

--- a/README.md
+++ b/README.md
@@ -1916,6 +1916,7 @@ to simplify usage and allow quick customization.
 * [ng-virtual-list](https://github.com/djonnyx/ng-virtual-list) - Maximum performance for extremely large lists. It is based on algorithms for virtualization of screen objects.
 * [ngx-horizontal-menu-scroll](https://github.com/isahohieku/ngx-horizontal-menu-scroll) - A lightweight, customizable Angular library for creating beautiful horizontal scrolling menus with smooth navigation controls.
 * [usal](https://github.com/italoalmeida0/usal) - Framework agnostic ultimate scroll animation library.
+* [ar-virtual-scroll](https://github.com/artomenwork/ar-virtual-scroll) — Lightweight Angular virtual scroll with automatic dynamic height measurement. Ideal for chats, message feeds and variable-height lists. Better alternative to Angular CDK virtual scroll when dynamic heights are required.
 
 ### Storage
 


### PR DESCRIPTION
This PR adds ar-virtual-scroll - a lightweight Angular virtual scroll library with automatic dynamic height measurement.

Angular CDK virtual scroll does not support variable item heights. This library provides a simple Datasource API and precise height caching, making it ideal for:

• Chats and messaging UIs  
• Infinite feeds  
• Dynamic variable-height lists  

Repository: https://github.com/artomenwork/ar-virtual-scroll  
npm: https://www.npmjs.com/package/ar-virtual-scroll

The library is small, stable and solves a real problem frequently discussed in the Angular community.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an entry for ar-virtual-scroll to the Angular Scroll section, describing it as a lightweight virtual scroll with automatic dynamic-height measurement for chats, message feeds, and variable-height lists.
  * Added the same ar-virtual-scroll entry to the Storage/library listing to improve discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->