### PR TITLE
docs: add hugeicons-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1610,6 +1610,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [chill-wind-icons](https://github.com/alimjanablikim/chill-wind-icons) - Dynamic Angular icon library with native Tailwind CSS support, tree-shakeable icon data, and built from Iconoir SVGs.
 * [@TSB04/svg-icon](https://github.com/TSB04/svg-icon) - Framework-agnostic, customizable, lightweight SVG icon package for React, Vue, Angular, and more.
 * [animated-icons](https://github.com/ajitzero/animated-icons) - Animated icons for Angular based on [moving icons](https://www.movingicons.dev/).
+* [hugeicons-angular](https://github.com/hugeicons/angular) - 4,600+ free MIT-licensed stroke-rounded icons for Angular.
 
 ### Images
 


### PR DESCRIPTION
Add [hugeicons-angular](https://github.com/hugeicons/angular) to the Icons section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added hugeicons-angular to the Icons section - a library featuring 4,600+ free MIT-licensed stroke-rounded icons for Angular.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->