### PR TITLE
Add @witqq/spreadsheet to Data Grids section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,6 +1333,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [cerious-grid](https://github.com/ryoucerious/cerious-widgets) - A seriously powerful Angular grid for developers who demand control, flexibility, and performance.
 * [ngxsmk-datatable](https://github.com/toozuuu/ngxsmk-datatable) - Modern Angular 17+ datatable focused on performance, customization, and developer experience.
 * [ngx-column-filter](https://github.com/kakarotx10/ngx-column-filter) - A powerful, reusable Angular column filter component with support for multiple field types, advanced filtering rules, and customizable match modes.
+* [@witqq/spreadsheet](https://spreadsheet.witqq.dev/) - Canvas-based spreadsheet and datagrid engine with zero dependencies, 100K+ rows at 60fps, editing, formulas, sorting, filtering, and real-time collaboration. Standalone Angular component wrapper.
 * [Jspreadsheet CE](https://github.com/jspreadsheet/ce) - Open source JavaScript spreadsheet and data grid component, can be used in Angular apps when wrapped or consumed via Angular elements.
 * [TabularJS](https://github.com/jspreadsheet/tabularjs) - Lightweight JavaScript table and data grid library for advanced table features in Angular.
 * [uni-table](https://github.com/Unify-India/uni-table) - Angular data grid built on signals for zero‑lag performance, combining advanced server‑side features with a streamlined configuration API.

--- a/README.md
+++ b/README.md
@@ -1333,7 +1333,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [cerious-grid](https://github.com/ryoucerious/cerious-widgets) - A seriously powerful Angular grid for developers who demand control, flexibility, and performance.
 * [ngxsmk-datatable](https://github.com/toozuuu/ngxsmk-datatable) - Modern Angular 17+ datatable focused on performance, customization, and developer experience.
 * [ngx-column-filter](https://github.com/kakarotx10/ngx-column-filter) - A powerful, reusable Angular column filter component with support for multiple field types, advanced filtering rules, and customizable match modes.
-* [@witqq/spreadsheet](https://spreadsheet.witqq.dev/) - Canvas-based spreadsheet and datagrid engine with zero dependencies, 100K+ rows at 60fps, editing, formulas, sorting, filtering, and real-time collaboration. Standalone Angular component wrapper.
+* [@witqq/spreadsheet](https://github.com/witqq/spreadsheet) - Canvas-based spreadsheet and datagrid engine with zero dependencies, 100K+ rows at 60fps, editing, formulas, sorting, filtering, and real-time collaboration. More details on this [website](https://spreadsheet.witqq.dev/).
 * [Jspreadsheet CE](https://github.com/jspreadsheet/ce) - Open source JavaScript spreadsheet and data grid component, can be used in Angular apps when wrapped or consumed via Angular elements.
 * [TabularJS](https://github.com/jspreadsheet/tabularjs) - Lightweight JavaScript table and data grid library for advanced table features in Angular.
 * [uni-table](https://github.com/Unify-India/uni-table) - Angular data grid built on signals for zero‑lag performance, combining advanced server‑side features with a streamlined configuration API.


### PR DESCRIPTION
**[@witqq/spreadsheet](https://github.com/witqq/spreadsheet)** — Canvas-based spreadsheet and datagrid engine with standalone Angular component wrapper.

### Why it's awesome
- Renders **100K+ rows at 60fps** using Canvas 2D with zero external dependencies
- Standalone Angular component wrapper with Input/Output bindings
- Full spreadsheet features: formulas, sorting, filtering, clipboard, undo/redo, cell merge, frozen panes
- Real-time collaboration via OT engine
- TypeScript strict mode, ~36KB gzipped widget bundle

### Links
- [GitHub](https://github.com/witqq/spreadsheet)
- [Live Demo](https://spreadsheet.witqq.dev/)
- [npm](https://www.npmjs.com/package/@witqq/spreadsheet)

Added to **Data Grids** section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a reference to a canvas-based spreadsheet and datagrid engine (zero dependencies, 100K+ rows at 60fps, editing, formulas, sorting, filtering, real-time collaboration).
  * Added a new entry for "ogrid" to the Data Grids list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->