### PR TITLE
docs: add web-serial-rxjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2230,6 +2230,7 @@ for the creation of web applications developed with Angular.
 * [rxjs-course](https://github.com/angular-university/rxjs-course) - RxJS course from Angular University.
 * [subscribable-things](https://github.com/chrisguttandin/subscribable-things) - A collection of reactive wrappers for various browser APIs.
 * [subsiphon](https://github.com/shobeiry/subsiphon) - Lightweight utility for managing multiple RxJS subscriptions with indexed/named keys and simple cleanup methods.
+* [web-serial-rxjs](https://github.com/gurezo/web-serial-rxjs) - A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.
 
 ### TypeScript
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Official Resources entry: web-serial-rxjs — a TypeScript RxJS wrapper for the Web Serial API to simplify reactive serial-port communication in web apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->