### PR TITLE
Add MapMetrics GL to Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1755,6 +1755,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [angular-yandex-maps](https://github.com/ddubrava/angular-yandex-maps) - Yandex.Maps Angular components that implement the Yandex.Maps JavaScript API.
 * [workletjs](https://github.com/workletjs/workletjs) - An Angular map component library that provides seamless integration with OpenLayers, enabling developers to create interactive and customizable maps.
 * [ng-simple-maps](https://github.com/hanafnafs/ng-simple-maps) - Beautiful, lightweight SVG world maps for Angular applications.
+* [mapmetrics-gl](https://github.com/MapMetrics/mapmetrics-gl) - Mapbox GL JS-compatible mapping library with built-in tiles, geocoding, routing, and search.
 
 ### Markdown
 


### PR DESCRIPTION
Adding MapMetrics GL to the Maps section.

MapMetrics GL is a Mapbox GL JS-compatible mapping library with built-in support for map tiles, geocoding, routing, and search. Works with Angular. EU-hosted, GDPR compliant.

GitHub: https://github.com/MapMetrics/mapmetrics-gl
Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Maps section of the README with a new mapping library option compatible with Mapbox GL JS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->