### PR TITLE
 docs: add domternal to Editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1454,6 +1454,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [acrodata/code-editor](https://github.com/acrodata/code-editor) - CodeMirror 6 wrapper for Angular.
 * [angular2-froala-wysiwyg](https://github.com/froala/angular-froala-wysiwyg) - Angular wrapper for Froala WYSIWYG HTML Editor.
 * [ckeditor](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/angular.html) - Plugin for Angular.
+* [domternal](https://github.com/domternal/domternal) - Lightweight, extensible rich text editor toolkit with native Angular components (Signals, OnPush, standalone), built-in toolbar and theme, and full table support.
 * [ngx-aztreya-editor](https://github.com/aztreya/ngx-aztreya-editor) - A lightweight, customizable Angular Rich Text Editor component with built-in toolbar, headings, text formatting, and alignment options.
 * [ngx-simple-text-editor](https://github.com/Raiper34/ngx-simple-text-editor) - Ngx Simple Text editor or ST editor is a simple native text editor component for Angular 9+.
 * [ngx-quill](https://github.com/KillerCodeMonkey/ngx-quill) - Angular components for the Quill Rich Text Editor.


### PR DESCRIPTION
Added [Domternal](https://domternal.dev) to the Editors section.

Domternal is a lightweight, extensible rich text editor toolkit built on ProseMirror with native Angular components (Signals, OnPush, standalone), built-in toolbar and theme, and full table support.

- Website: https://domternal.dev
- GitHub: https://github.com/domternal/domternal
- npm: https://www.npmjs.com/org/domternal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "domternal" editor entry to the Editors section, including its repository link and feature description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->