### PR TITLE
docs: add mat-password-meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,6 +1591,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-pattern-lock](https://github.com/nicotole/ngx-pattern-lock) - A lightweight, fully responsive, and customizable Android-style pattern lock component for Angular.
 * [smt-select](https://github.com/sametacar/smt-select) - A high-performance, lightweight, and customizable Angular select component with built-in virtual scroll and search capabilities.
 * [ngx-mat-searchable-select](https://github.com/khalilElmouedene/ngx-mat-searchable-select) - A reusable Angular Material select component with infinite scroll, debounced search, "no items found" feedback, and static/mock data support.
+* [mat-password-meter](https://github.com/ngx-zen/mat-password-meter) - Three Angular Material password strength components with a signals-based API.
 
 ### JSON Forms
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended the Form Controls section to reference a new Angular Material password strength component library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->