### PR TITLE
docs: add angular-inport

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,6 +1430,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [angular-paginator](https://github.com/sibiraj-s/angular-paginator) - Pagination Component for Angular applications.
 * [ngx-signal-combinators](https://github.com/alessiopelliccione/ngx-signal-combinators) - Composable boolean helpers for Angular signals, enabling cleaner reactive template logic.
 * [viewport-truth](https://github.com/AntonVoronezh/viewport-truth) - A tiny VisualViewport‑first store for accurate CSS‑pixel viewport size that detects virtual keyboards, reduces resize/scroll jitter, and works with SSR across frameworks.
+* [angular-inport](https://github.com/ajaysinghj8/angular-inport) - Angular In-Viewport Detector.
 
 ### Drag and Drop
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a reference to an Angular In-Viewport Detector tool in the documentation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->