### PR TITLE
docs: add ngx-ace-signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1493,6 +1493,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [Monaco Pattern Editor](https://github.com/KhlifiIsmail/Editor) - A premium Angular library that wraps Monaco Editor with beautiful themes and coding interview preparation features.
 * [angular-editor](https://github.com/kolkov/angular-editor) - A simple native WYSIWYG editor component for Angular.
 * [ngx-json-editor](https://github.com/RonnyValdivieso/ngx-json-editor) - A minimal, themeable JSON editor for Angular.
+* [ngx-ace-signal](https://github.com/WebArtWork/ngx-ace-signal) - A modern Angular signals-based wrapper for the Ace editor.
 
 ### File Upload
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the "Editors" section in README.md to include a new entry for `ngx-ace-signal`, a modern Angular signals-based wrapper for the Ace editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->