### PR TITLE
docs: add ngStato

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-state-crafter](https://github.com/irvrodflo/ngx-state-crafter) - A lightweight, signal‑driven state library for Angular with a clean, boilerplate‑free API.
 * [coaction](https://github.com/unadlib/coaction) - An efficient and flexible state management library for building high-performance, multithreading web applications.
 * [flurryx](https://github.com/fmflurry/flurryx) - A signal-first reactive state toolkit for Angular that bridges RxJS streams into structured, cache-aware stores.
+* [ngStato](https://github.com/becher/ngStato) - State management for Angular that uses async/await instead of RxJS.
 
 ## Testing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated state management resources to include ngStato, an Angular state management library alternative using async/await instead of traditional reactive approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->