### PR TITLE
Add enterprise-java-saas-starter-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [teleport-code-generators](https://github.com/teleporthq/teleport-code-generators) - A collection of code generators for modern JavaScript applications.
 * [Bootify.io](https://bootify.io) - Generate Spring Boot apps with custom database, Angular frontend and CRUD functionality.
 * [jangular-cli](https://github.com/nathangtg/jangular-cli) - A Spring Boot + Angular starter kit with JWT auth, Flyway migrations, route protection, and CLI setup.
+* [enterprise-java-saas-starter-kit](https://github.com/zukovlabs/enterprise-java-saas-starter-kit) - Production-ready SaaS starter with Java 21, Spring Boot 3.4, Angular 21 (Standalone + Signals), MSSQL, JWT auth, and Docker Compose.
 * [JHipster](https://www.jhipster.tech) - Open source app generator for Spring Boot and Angular.
 * [ng-openapi](https://github.com/ng-openapi/ng-openapi) - Angular OpenAPI Client Generator.
 * [tmf](https://github.com/tripsnek/tmf) - A lightweight TypeScript port of Eclipse Modeling Framework (EMF) for model-driven, type-safe data models across Node.js, Java, and Angular/React.


### PR DESCRIPTION
Added enterprise-java-saas-starter-kit — a fullstack SaaS starter with Java 21, Spring Boot 3.4.1, Angular 21 (Standalone Components + Signals), MSSQL + Flyway, JWT authentication, and Docker Compose with healthchecks. MIT licensed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new enterprise-grade starter kit option featuring Java 21, Spring Boot 3.4, Angular 21 (Standalone + Signals), MSSQL, JWT authentication, and Docker Compose support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->