### PR TITLE
Add ngx-transforms to the list of Angular pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1875,6 +1875,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-smart-pipes](https://github.com/Kavshree/-bjkavyashree-ngx-smart-pipes) - A lightweight, tree-shakeable collection of standalone Angular pipes designed for real-world use cases.
 * [ngx-dynamic-search](https://github.com/mustafaer/ngx-dynamic-search) - Angular pipe designed for dynamic, deep search filtering across complex nested objects and arrays.
 * [ngx-name-capitalize](https://github.com/gabo2151/ngx-name-capitalize) - Angular pipe for name capitalization that formats compound surnames, linguistic particles, hyphenated names, apostrophes, and Unicode characters.
+* [ngx-transforms](https://github.com/mofirojean/ngx-transforms) - 90+ standalone, tree-shakable pipes for strings, numbers, dates, arrays, objects, and more.
 
 ### Printing
 


### PR DESCRIPTION
Adds `ngx-transforms` to the Pipes section.
**What it is:** A library of 90+ standalone, tree-shakable Angular pipes covering string transforms, numeric helpers, date/time, arrays, objects, booleans, and a handful of utilities (QR code, barcode, Gravatar, masking).

**Why it fits:** It's a focused, multi-pipe library that gives Angular developers a single dependency for the common template-side transforms they'd otherwise hand-roll -text, numbers, dates, arrays, objects, and boolean discriminators. Every pipe is standalone, pure, and tree-shaken, so consumers pay only for what they import.

**Quality signals:**
- Angular 17-21 (verified via daily multi-version CI matrix)
- Standalone pipes, `sideEffects: false`, tree-shakable
- ~170 KB FESM bundle, ~28 KB gzipped (size-limit enforced in CI)
- Vitest suite + publint clean
- Docs site: https://ngx-transforms.vercel.app
- MIT licensed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with information about the ngx-transforms pipe.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PatrickJS/awesome-angular/pull/2190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->