### PR TITLE
docs: add angular-multiselect-dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,6 +1565,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-colors2](https://github.com/DominicWrege/ngx-colors) - A material‑style Angular color‑picker updated for Angular 20+, using signals and no animation dependencies.
 * [ngx-signal-datetimepicker](https://github.com/dominikmodrzejewski99/ngx-signal-datetimepicker) - Angular datetime picker built on Signal Forms — date + time in one control, zero deps, WCAG 2.2 AAA out of the box.
 * [ngx-multi-field-dropdown](https://github.com/luismtapiab/ngx-multi-field-dropdown) - A customizable Angular searchable dropdown component with multi-field search support.
+* [angular-multiselect-dropdown](https://github.com/alexandroit/angular-multiselect-dropdown) - A maintained, ADA-compliant Angular multiselect dropdown built for template-driven and reactive forms
 
 ### JSON Forms
 

--- a/README.md
+++ b/README.md
@@ -1565,7 +1565,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-colors2](https://github.com/DominicWrege/ngx-colors) - A material‑style Angular color‑picker updated for Angular 20+, using signals and no animation dependencies.
 * [ngx-signal-datetimepicker](https://github.com/dominikmodrzejewski99/ngx-signal-datetimepicker) - Angular datetime picker built on Signal Forms — date + time in one control, zero deps, WCAG 2.2 AAA out of the box.
 * [ngx-multi-field-dropdown](https://github.com/luismtapiab/ngx-multi-field-dropdown) - A customizable Angular searchable dropdown component with multi-field search support.
-* [angular-multiselect-dropdown](https://github.com/alexandroit/angular-multiselect-dropdown) - A maintained, ADA-compliant Angular multiselect dropdown built for template-driven and reactive forms
+* [angular-multiselect-dropdown](https://github.com/alexandroit/angular-multiselect-dropdown) - A maintained Angular multiselect dropdown built for template-driven and reactive forms.
 
 ### JSON Forms
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry under Form Controls for "angular-multiselect-dropdown" with a link to its repository and a concise description. Notes that this is a maintained Angular multiselect dropdown supporting both template-driven and reactive forms, making it a documented option for adding multiselect behavior in form UIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->