### PR TITLE
docs: add ngx-cupertino

### DIFF
--- a/README.md
+++ b/README.md
@@ -2070,6 +2070,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-pk-ui](https://github.com/superpck/ngx-pk-ui) - An Angular 21 component library providing UI components and CSS utilities.
 * [magary](https://github.com/JhoanGon/magary) - A modern, standalone-first Angular UI library monorepo.
 * [ngx-core-components](https://github.com/prajaktadube/ngx-core-components) - Angular 19+ component library — production-ready UI components built with signals, OnPush change detection, and zero runtime dependencies.
+* [ngx-cupertino](https://github.com/gacc94/ngx-cupertino) - Angular components implementing Apple's iOS 26 / macOS Tahoe 26 design system.
 
 ### UI Libraries built on Bootstrap
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README's UI Libraries section to include ngx-cupertino, an Angular component library implementing Apple's iOS 26 / macOS Tahoe 26 design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->