### PR TITLE
Add ngx-herald to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1880,6 +1880,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-dynamic-toast](https://github.com/ederjavs/ngx-dynamic-toast) - An elegant, liquid-smooth toast notification library for Angular, heavily inspired by the beautiful [Sileo](https://github.com/hiaaryan/sileo) project.
 * [flexi-toast](https://github.com/FlexiUI-labs/flexi-toast) - Angular toast notification component with title, message, icon types, auto-dismiss, manual close, animations, theme, and positioning support.
 * [ngx-notitia](https://github.com/klajdm/ngx-notitia) - Updated fork of `ngx-toastr` with additional features, fixes, and modernizations for Angular 21+.
+* [ngx-herald](https://github.com/HoplaGeiss/ngx-herald) - A lightweight, modern Angular toast notification library. Signals-first, zoneless-compatible, zero runtime dependencies, and an easy-to-use alternative to ngx-toastr.
 
 ### Onboarding and Product Tours
 


### PR DESCRIPTION
Added ngx-herald to the list of Angular toast notification libraries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new notification library entry to the README's Notifications section, highlighting a lightweight, modern Angular toast notification library featuring a signals-first architecture and zoneless-compatible design with zero runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->