### PR TITLE
docs: add ngx-trpc-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [api-caller](https://forge.deejayy.hu/angular-packages/api-caller) - Simple API caller library for Angular.
 * [ngx-lite-cache](https://github.com/Suleeyman/ngx-lite-cache) - An Angular library that caches HTTP responses via HttpClient interceptors to cut redundant requests and boost performance.
 * [ng-qubee](https://github.com/AndreaAlhena/ng-qubee) - Angular query builder with reactive URIs (RxJS + Signals), typed pagination, 495+ tests, and multi‑driver support.
+* [ngx-trpc-client](https://github.com/BeGj/ngx-trpc-client) - Reworked fork of Analog's [TRPC package](https://github.com/analogjs/analog/tree/beta/packages/trpc).
 
 ### Micro-Frontends
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the HTTP section in the README with an additional entry for `ngx-trpc-client`.
  * Added a reference link to the upstream Analog TRPC package for easier comparison and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->