### PR TITLE
docs: add michi-vz-mono

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [carbon-charts](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/angular) - Carbon Charts Angular is a thin Angular wrapper around the vanilla JavaScript @carbon/charts component library.
 * [Foblex](https://flow.foblex.com/) - Angular Powered Flow-Chart Library.
 * [highcharts-angular](https://github.com/highcharts/highcharts-angular) - Official minimal [Highcharts](https://www.highcharts.com/) integration for Angular.
+* [michi-vz-mono](https://github.com/beany-vu/michi-vz-mono) - One engine powering 17 interactive, accessible chart types with seamless support for Angular and more, all emitting LLM‑ready data for reports, dashboards, and AI features.
 * [ng-apexcharts](https://github.com/apexcharts/ng-apexcharts) - Angular wrapper for ApexCharts to build interactive visualizations.
 * [ng-chartist](https://github.com/willsoto/ng-chartist) - Angular component for [Chartist.js](https://github.com/chartist-js/chartist).
 * [ng-diagram](https://github.com/synergycodes/ng-diagram) - Angular library for building interactive, customizable diagrams, node-based editors, and visual workflows.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new chart entry, **michi-vz-mono**, to the Charts list.
  * Included a short description highlighting support for interactive, accessible chart types, Angular, and LLM-ready output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->