### PR TITLE
Add @stitchapi/angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ng-qubee](https://github.com/AndreaAlhena/ng-qubee) - Angular query builder with reactive URIs (RxJS + Signals), typed pagination, 495+ tests, and multi‑driver support.
 * [ngx-trpc-client](https://github.com/BeGj/ngx-trpc-client) - Reworked fork of Analog's [TRPC package](https://github.com/analogjs/analog/tree/beta/packages/trpc).
 * [zx-angular-lazy-resource](https://github.com/zxnc/zx-angular-lazy-resource) - Lazy helpers for Angular's signal-based `resource()` — defer loading until first access, and await the first settled value as a promise.
+* [@stitchapi/angular](https://github.com/rejifald/StitchAPI/tree/main/packages/angular) - Streaming-first StitchAPI bindings: `injectStitch` / `injectStitchStream` expose a typed, validated call as both Angular signals and an RxJS observable, re-rendering as response deltas arrive.
 
 ### Micro-Frontends
 


### PR DESCRIPTION
Adds `@stitchapi/angular` to the bottom of **Architecture and Advanced Topics → HTTP**.

Typed, validated Angular bindings over a single [StitchAPI](https://stitchapi.dev) definition. What makes it different from the other HTTP entries: `injectStitch` / `injectStitchStream` expose one shared execution as **both Angular signals and an RxJS observable** — templates read the signals while effects/pipes consume the observable, with no second request. It's also **streaming-first**: `injectStitchStream` surfaces each response *delta* as it arrives (SSE / chunked streams). An optional TanStack Query `queryOptions` adapter is included.

- Source: https://github.com/rejifald/StitchAPI/tree/main/packages/angular
- npm: https://www.npmjs.com/package/@stitchapi/angular

Per the contribution guidelines: individual PR for a single suggestion, succinct description, added to the bottom of the relevant category.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the HTTP section of the README with a new library entry describing streaming-first StitchAPI bindings for Angular, including support for signals and an RxJS observable interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->