### PR TITLE
docs: add streamdown-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1786,6 +1786,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [mark-down](https://github.com/mzebley/mark-down) - A framework‑agnostic snippet engine with an Angular adapter that indexes Markdown at build time and renders HTML at runtime with optional sanitization.
 * [m-render](https://github.com/Foblex/m-render) - A library for rendering Markdown with extended support for Angular components and code snippets.
 * [markstream](https://github.com/Simon-He95/markstream-vue) - Render Markdown while it is still streaming.
+* [streamdown-angular](https://github.com/XurshidJurayev1/streamdown-angular) - Stream‑safe Markdown rendering for Angular, built for AI chat UIs. Angular port of [Vercel Streamdown](https://github.com/vercel/streamdown).
 
 ### Media
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Markdown list entry for an Angular stream-safe Markdown rendering library, highlighting its fit for AI chat interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->