### PR TITLE
docs: add schedula-core-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [org-chart](https://github.com/bumbeishvili/org-chart) - Highly customizable org chart. Integrations available for Angular, React, and Vue.
 * [pioneer-charts](https://github.com/PioneerCode/pioneer-charts) - An Angular library for creating responsive, customizable charts using D3.js—supports bar, line, pie, and more.
 * [sequential-workflow-designer](https://github.com/nocode-js/sequential-workflow-designer) - Customizable no-code component for building flow-based programming applications or workflow automation. Zero external dependencies.
+* [schedula-core-angular](https://github.com/RGabGH/schedula-core/tree/main/integrations/packages/angular) - Official Angular wrapper for [SchedulaCore](https://www.npmjs.com/package/schedula-core) — a fast, lightweight Gantt chart & resource scheduler component.
 * [systelab-charts](https://github.com/systelab/systelab-charts) - Systelab Angular Chart services.
 * [unovis](https://github.com/f5/unovis) - Modular data visualization framework for React, Angular, Svelte, Vue, and vanilla TypeScript or JavaScript.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the Charts section for `schedula-core-angular`.
  * Clarified that it is an official Angular wrapper for the SchedulaCore scheduling and Gantt chart component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->