### PR TITLE
docs: add NgStarter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1182,6 +1182,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [CozyDevKit](https://cozydevkit.com/) - Interactive tools, architecture patterns, cheat sheets, and DevOps services for Angular 21.
 * [devkitly](https://www.devkitly.io/) - Production-ready Angular 21 starter kit with auth, billing, audit logging, feature flags, and SSR.
 * [draftNG](https://www.draftng.xyz/) - Minimalist & high-performance Angular 22+ platform templates.
+* [NgStarter](https://ngstarter.com/) - Angular UI Components & Admin Templates.
 * [Nzoni](https://nzoni.app/) - Launch your SAAS in days with Angular.
 * [Theme Forest](https://themeforest.net/search/angular)
 * [Vortex](https://template.giacomobellazzi.com/) - A high-performance web application template built with Angular and Java, designed to deliver seamless user experiences and powerful backend solutions.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Paid Templates list to include NgStarter as an additional paid Angular template option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->