### PR TITLE
Update Foblex Flow entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1295,7 +1295,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [angular-chrts](https://github.com/dennisadriaans/angular-chrts) - A high-performance, developer-friendly data visualization library for modern Angular applications.
 * [angular-google-charts](https://github.com/FERNman/angular-google-charts) - A wrapper for the Google Charts library written in Angular.
 * [carbon-charts](https://github.com/carbon-design-system/carbon-charts/tree/master/packages/angular) - Carbon Charts Angular is a thin Angular wrapper around the vanilla JavaScript @carbon/charts component library.
-* [Foblex](https://flow.foblex.com/) - Angular Powered Flow-Chart Library.
+* [Foblex Flow](https://github.com/Foblex/f-flow) - Angular-native library for node editors, workflow builders and interactive diagrams: drag-and-drop nodes and connections, minimap, auto-layout, virtualization, and a keyboard accessibility layer.
 * [highcharts-angular](https://github.com/highcharts/highcharts-angular) - Official minimal [Highcharts](https://www.highcharts.com/) integration for Angular.
 * [michi-vz-mono](https://github.com/beany-vu/michi-vz-mono) - One engine powering 17 interactive, accessible chart types with seamless support for Angular and more, all emitting LLM‑ready data for reports, dashboards, and AI features.
 * [ng-apexcharts](https://github.com/apexcharts/ng-apexcharts) - Angular wrapper for ApexCharts to build interactive visualizations.


### PR DESCRIPTION
Updates the existing Foblex Flow entry in the Charts section:

- points to the GitHub repository (matching neighboring entries) instead of the marketing site
- replaces the outdated one-liner ("Angular Powered Flow-Chart Library") with a succinct description of what the library actually covers today: node editors, workflow builders and interactive diagrams with drag-and-drop nodes/connections, minimap, auto-layout, virtualization, and a keyboard accessibility layer

One suggestion per PR, existing entry, no new category. I'm the maintainer of the library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Charts section to reference **Foblex Flow** instead of **Foblex**.
  * Refreshed the linked resource and description to match the latest Angular-native node editor and workflow tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->