### PR TITLE
docs: add angular-typed-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1994,6 +1994,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ui-router](https://github.com/ui-router/angular) - State-based routing in Angular is enabled through [UI-Router for Angular](https://ui-router.github.io).
 * [ngx-url-params](https://github.com/shlomog12/ngx-url-params) - Lightweight Angular service for managing and synchronizing URL query parameters with a concise, reactive API.
 * [ngx-history](https://github.com/lumentut/ngx-history) - Modern Angular navigation history service with reactive programming support.
+* [angular-typed-router](https://github.com/dominicbachmann/angular-typed-router) - Type‑safe Angular navigation from a single Routes array, yielding inferred path unions and typed navigate tuples with zero codegen or runtime cost.
 
 ### Scroll
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Router resource list to include `angular-typed-router` in the Angular section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->