### PR TITLE
docs: add ngx-json-forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1633,6 +1633,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-formbar](https://github.com/TheNordicOne/ngx-formbar) - A highly flexible framework for generating declarative reactive forms.
 * [formitiva](https://github.com/formitiva/formitiva-monorepo) - A framework-agnostic runtime form engine for building forms from JSON schemas.
 * [filter](https://github.com/some-angular-utils/filter) - Define fields once to get a ready-to-use JSON object and URL query string on every search.
+* [ngx-json-forms](https://github.com/Raghav-Pal-dev/ngx-json-forms) - A zero-template, JSON-driven Angular form engine featuring over 40 field types, advanced validation, conditional logic, wizards, and repeaters.
 
 ### Form Validation
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ngx-json-forms` to the JSON Forms section, highlighting its Angular form engine, supported field types, validation, conditional logic, wizards, and repeaters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->