### PR TITLE
Add GeoIcons To Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1674,6 +1674,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [animated-icons](https://github.com/ajitzero/animated-icons) - Animated icons for Angular based on [moving icons](https://www.movingicons.dev/).
 * [hugeicons-angular](https://github.com/hugeicons/angular) - 5,100+ free MIT-licensed stroke-rounded icons for Angular.
 * [@quikturn-sdk/logos-angular](https://github.com/quikturn-sdk/Company-Logos) - TypeScript SDK for the [Quikturn Logos API](https://getquikturn.io/) - Fetch any company's logo by domain name.
+* [GeoIcons](https://geoicons.io) - Geographic map icons for every country, territory, and world region, as tree-shakeable Angular standalone components.
 
 ### Images
 

--- a/README.md
+++ b/README.md
@@ -1674,7 +1674,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [animated-icons](https://github.com/ajitzero/animated-icons) - Animated icons for Angular based on [moving icons](https://www.movingicons.dev/).
 * [hugeicons-angular](https://github.com/hugeicons/angular) - 5,100+ free MIT-licensed stroke-rounded icons for Angular.
 * [@quikturn-sdk/logos-angular](https://github.com/quikturn-sdk/Company-Logos) - TypeScript SDK for the [Quikturn Logos API](https://getquikturn.io/) - Fetch any company's logo by domain name.
-* [GeoIcons](https://geoicons.io) - Geographic map icons for every country, territory, and world region, as tree-shakeable Angular standalone components.
+* [GeoIcons](https://geoicons.io) - Geographic map icons for every country, territory, and world region as tree-shakable Angular standalone components.
 
 ### Images
 


### PR DESCRIPTION
Adds GeoIcons to the bottom of the Icons category, per contributing guidelines.

GeoIcons is a set of geographic map icons covering every country, territory, and world region, each a tree-shakeable Angular standalone component, themeable with currentColor.

Site: https://geoicons.io
Github: https://github.com/getgeoicons/geoicons/tree/main/packages/angular

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added GeoIcons to the list of available icons in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->