### PR TITLE
docs: add ngx-yet-another-toast-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1933,6 +1933,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-notitia](https://github.com/klajdm/ngx-notitia) - Updated fork of `ngx-toastr` with additional features, fixes, and modernizations for Angular 21+.
 * [ngx-herald](https://github.com/HoplaGeiss/ngx-herald) - A lightweight, modern Angular toast notification library. Signals-first, zoneless-compatible, zero runtime dependencies, and an easy-to-use alternative to ngx-toastr.
 * [ngx-gooey-toast](https://github.com/juanvieiraprado99/ngx-gooey-toast) - A morphing pill‑to‑blob toast component for Angular, serving as an Angular port of the React [gooey‑toast](https://goey-toast.vercel.app/).
+* [ngx-yet-another-toast-library](https://github.com/Zeeraa/ngx-yet-another-toast-library) - A lightweight, signal-based Angular toast notification library with Bootstrap 5 color palette support.
 
 ### Onboarding and Product Tours
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ngx-yet-another-toast-library` to the README’s notifications list.
  * Described it as a lightweight, signal-based Angular toast library with Bootstrap 5 color palette support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->