### PR TITLE
docs: add ngx-wp-shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2371,6 +2371,7 @@ for the creation of web applications developed with Angular.
 * [alterior](https://github.com/alterior-mvc/alterior) - Isomorphic TypeScript framework for building modular services with seamless Angular integration.
 * [23blocks SDK](https://github.com/23blocks-OS/frontend-sdk) - Build full-stack apps 10x faster with modular backend blocks.
 * [ngx-unity](https://github.com/jjmhalew/ngx-unity) - A type-safe bridge for bidirectional communication between Unity WebGL/WebGPU and Angular.
+* [ngx-wp-shortcode](https://codeberg.org/tomaszatoo/ngx-wp-shortcode.git) - A library that lets Angular applications render WordPress shortcodes as native Angular components.
 
 ### Wrappers
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ngx-wp-shortcode` to the external integration library list.
  * Documented support for rendering WordPress shortcodes as native Angular components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->