### PR TITLE
Add @bloklabs/angular to Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1518,6 +1518,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-email-studio](https://github.com/edward124689/ngx-email-studio) - An Angular 21 frontend email builder for composing, importing, editing, previewing, and exporting responsive email templates.
 * [qalma](https://github.com/cdskill/qalma) - Angular-first, headless rich text editor toolkit built on ProseMirror.
 * [ngx-mermaid-canvas](https://github.com/Nigelli/ngx-mermaid-canvas) - A visual flowchart editor for Angular that outputs Mermaid syntax.
+* [@bloklabs/angular](https://github.com/JackUait/blok) - Angular adapter for [Blok](https://blokeditor.com), a headless block-based rich text editor that outputs JSON instead of HTML.
 
 ### File Upload
 


### PR DESCRIPTION
Adds the Angular adapter for [Blok](https://github.com/JackUait/blok) to the Editors section.

Blok is a headless, block-based rich text editor that stores content as JSON blocks rather than HTML. `@bloklabs/angular` is a first-party adapter (alongside React and Vue) published as part of the same repo.

- Repo: https://github.com/JackUait/blok
- Docs: https://blokeditor.com
- npm: https://www.npmjs.com/package/@bloklabs/angular

Guidelines checked: single suggestion, appended to the bottom of the relevant category, no duplicate (searched `blok`), MIT-licensed and free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `@bloklabs/angular` to the list of third-party Angular editor libraries.
  * Clarified that the adapter outputs JSON rather than HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->