### PR TITLE
Add NgBracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -2173,6 +2173,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [coss-ui-angular](https://github.com/lordsarcastic/coss-ui-angular) - Accessible Angular components inspired by the public [COSS UI catalogue](https://www.coss.com/ui/docs).
 * [OpenMFP Web Components Library](https://github.com/openmfp/webcomponents) - A modern Angular 21 web components library featuring declarative UI components built with the latest signal-based APIs.
 * [ngxsmk-ui-kit](https://github.com/NGXSMK/ngxsmk-ui-kit) - 200+ free Angular components. Signals-native. Zoneless. Token-themed. Dark mode built in.
+* [NgBracket](https://ngbracket.com) - Accessibility-first Angular component packs (forms, data table, scheduler, charts, and more), signals-native on v22+ with Signal Forms; WCAG AA, keyboard + screen-reader tested by hand.
 
 ### UI Libraries built on Bootstrap
 


### PR DESCRIPTION
Adds NgBracket — a set of accessibility-first Angular component packs (forms, data table, scheduler, charts, dashboard, commerce, auth, marketing). Signals-native, built on the new Signal Forms, WCAG AA with hand-tested keyboard + screen-reader support. Added one line at the bottom of the **UI Libraries** category, per the contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added NgBracket to the UI Libraries list, including its website and a brief description of its accessibility-focused Angular components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->