### PR TITLE
Add Jobs in JS to Community Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [Map of GitHub](https://anvaka.github.io/map-of-github/#9.14/-21.9624/9.8143) - Explore the NgSphere to discover repositories with overlapping stargazers.
 * [Good First Issues](https://www.dolmen.tools/en/angular/good-first-issues/explorer) - Find beginner-friendly issues and start contributing to Angular open-source projects.
 * [Angular Popularity Analysis](https://github.com/ProjectBay/angular-popularity-analysis) - An AI-era normalized statistical analysis of Angular’s popularity.
+* [Jobs in JS](https://jobsinjs.com/angular-developer-jobs/) - Angular developer jobs in the US, Canada and UK. Updated daily.
 
 ### Newsletters
 


### PR DESCRIPTION
Adds Jobs in JS to the bottom of Angular Pulse → Community.

Free to use resource for Angular jobs. No paywall, no account- everything is available right away. We also calculate salary medians from the live listings.

Scoped to the US, Canada and the UK. Refreshed every 24 hours.

https://jobsinjs.com/angular-developer-jobs/

Single suggestion, appended to the bottom of the section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Jobs in JS” resource linking to Angular developer job opportunities in the Angular Pulse Community section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->