### PR TITLE
docs: add ngx-request-lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [@stitchapi/angular](https://github.com/rejifald/StitchAPI/tree/main/packages/angular) - Streaming-first StitchAPI bindings: `injectStitch` / `injectStitchStream` expose a typed, validated call as both Angular signals and an RxJS observable, re-rendering as response deltas arrive.
 * [angular-fetcher](https://github.com/aliomnt/angular-fetcher) - A modern, signal-based Angular library for seamless, type-safe remote API data management, handling fetching, mutations, and error tracking reactively.
 * [@some-angular-utils/paginator](https://github.com/some-angular-utils/paginator) - Simple, reliable pagination with two inputs: sliding window, jump buttons, disabled edges, and CSS-variable theming.
+* [ngx-request-lock](https://github.com/SalvatoreDiGenua/ngx-request-lock-docs) - An Angular library that binds a UI flow to the lifecycle of its HTTP requests.
 
 ### Micro-Frontends
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ngx-request-lock` to the list of HTTP-related libraries in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->