### PR TITLE
docs: add angular-tiptap-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1537,6 +1537,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [qalma](https://github.com/cdskill/qalma) - Angular-first, headless rich text editor toolkit built on ProseMirror.
 * [ngx-mermaid-canvas](https://github.com/Nigelli/ngx-mermaid-canvas) - A visual flowchart editor for Angular that outputs Mermaid syntax.
 * [@bloklabs/angular](https://github.com/JackUait/blok) - Angular adapter for [Blok](https://blokeditor.com), a headless block-based rich text editor that outputs JSON instead of HTML.
+* [angular-tiptap-editor](https://github.com/FloGeez/angular-tiptap-editor) - A modern, customizable Angular rich-text editor, built with Tiptap.
 
 ### File Upload
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `angular-tiptap-editor` to the list of supported editors in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->