### PR TITLE
docs: add ngx-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,6 +1078,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [editate](https://github.com/inokawa/editate) - An experimental, type-safe, framework agnostic and small (5kB+) contenteditable state manager.
 * [sdux-vault](https://github.com/sdux-vault/vault) - A framework-agnostic, deterministic state management system.
 * [ngx-tosijs](https://github.com/tonioloewald/ngx-tosijs) - Insanely simple state management for Angular — and an off-ramp from Angular. Take your pick.
+* [ngx-zero](https://github.com/ivan-anchev/ngx-zero) - Signals-first, zoneless-ready Angular bindings for [Rocicorp Zero](https://zero.rocicorp.dev/), a general-purpose sync solution.
 
 ## Testing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ngx-zero` to the README’s list of other state libraries, with a repository link and brief description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->