### PR TITLE
docs: add oSStack Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [angular-deploy-bunny](https://github.com/lostium/angular-deploy-bunny) - Angular Architect builder (`ng deploy`) that syncs your build to a Bunny.net CDN Storage Zone using SHA256 incremental diffing, then purges the corresponding Pull Zone.
 * [ngx-ssh-deploy](https://bitbucket.org/dkhang97/ngx-ssh-deploy/src/master/) - Deploy Angular projects using SSH.
 * [front-ready](https://github.com/czfabrics/front-ready) - Detects your Angular build settings, compiles the project, and uploads it to AWS S3 with optimized cache headers using a single command.
+* [oSStack Deploy](https://github.com/sanketpadhyal/oSStack-Deploy) - A high-performance deployment platform inspired by Vercel; features zero-config deployments, automated framework detection, and real-time build streaming.
 
 ### Desktop Applications
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added oSStack Deploy to the list of deployment resources.
  - Included a link to its GitHub repository and a brief description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->