### PR TITLE
docs: add nge-ide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-richtext](https://github.com/eliranbar/ng-rich-text-editor) - A professional rich text editor with free and premium feature tiers.
 * [ngx-image-editor](https://github.com/eliranbar/ngx-edit-images) - A professional image editor with a free forever tier and offline Ed25519-licensed premium tools.
 * [Scryb](https://scryb.dev/) - A $39/month flat-rate TypeScript WYSIWYG editor built on Tiptap that offers unlimited loads, end users, and documents.
+* [nge-ide](https://github.com/cisstech/nge-ide) - Via a single `<ide-root />` component, NGE IDE embeds a full desktop editor shell into Angular apps.
 
 ### File Upload
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `nge-ide` to the Editors section as an Angular-embeddable desktop editor shell.
  * Documented integration through a single `<ide-root />` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->