### PR TITLE
Add Arena by Dravensoft to UI Libraries built on Tailwind CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2273,7 +2273,7 @@ for the creation of web applications developed with Angular.
 
 * [angular-superui](https://github.com/bhaimicrosoft/angular-superui) - Comprehensive Angular UI library with 50+ production‑ready components, built on Tailwind CSS v4, TypeScript, and Angular 17+ Signals.
 * [angular-tailwind-ui](https://github.com/quedicesebas/angular-tailwind-ui) - Easy to use and simple components, directives and services. Using Angular 19 and Tailwind CSS 3.
-* [Arena by Dravensoft](https://github.com/dravensoft-dev/arena) - Token-driven Angular components on a shared Tailwind layer, published as the same design system for React, with every component API and accessibility pattern written as a contract file a gate holds. Brings no palette or fonts of its own.
+* [Arena by Dravensoft](https://github.com/dravensoft-dev/arena) - Token-driven Angular and React components sharing a Tailwind layer, governed by strict API and accessibility contract files, with no built-in palette or fonts.
 * [bpdm/ng](https://github.com/bpdm-hq/bpdm-ui) - Accessible, themeable Angular component library on the Angular CDK and Tailwind CSS, driven by a shared design-token set with a native React version.
 * [elbe-ui](https://github.com/marcjulian/elbe-ui) - Angular UI components built with Tailwind CSS and Spartan UI.
 * [Flowbite](https://flowbite.com/docs/getting-started/angular/) - Open-source UI components built with Tailwind CSS with support for Angular.

--- a/README.md
+++ b/README.md
@@ -2273,6 +2273,7 @@ for the creation of web applications developed with Angular.
 
 * [angular-superui](https://github.com/bhaimicrosoft/angular-superui) - Comprehensive Angular UI library with 50+ production‑ready components, built on Tailwind CSS v4, TypeScript, and Angular 17+ Signals.
 * [angular-tailwind-ui](https://github.com/quedicesebas/angular-tailwind-ui) - Easy to use and simple components, directives and services. Using Angular 19 and Tailwind CSS 3.
+* [Arena by Dravensoft](https://github.com/dravensoft-dev/arena) - Token-driven Angular components on a shared Tailwind layer, published as the same design system for React, with every component API and accessibility pattern written as a contract file a gate holds. Brings no palette or fonts of its own.
 * [bpdm/ng](https://github.com/bpdm-hq/bpdm-ui) - Accessible, themeable Angular component library on the Angular CDK and Tailwind CSS, driven by a shared design-token set with a native React version.
 * [elbe-ui](https://github.com/marcjulian/elbe-ui) - Angular UI components built with Tailwind CSS and Spartan UI.
 * [Flowbite](https://flowbite.com/docs/getting-started/angular/) - Open-source UI components built with Tailwind CSS with support for Angular.


### PR DESCRIPTION
Adding [Arena by Dravensoft](https://github.com/dravensoft-dev/arena) under **UI Libraries built on Tailwind CSS**, alphabetically between `angular-tailwind-ui` and `bpdm/ng`.

Arena publishes the same design system twice, as `@dravensoft/arena-angular` and `@dravensoft/arena-react`, over one shared Tailwind layer. The Angular layer ships standalone components, an Angular CDK base for the overlay and focus patterns, and a `metadata` entry point that writes the document head from the routes it is handed.

What is unusual enough to be worth the row: every component's API and the accessibility pattern it binds are contract files rather than documentation, and a gate fails the build when the code stops answering them. It also ships no palette and no fonts of its own; a project declares those in its own `arena.config.json` and a CLI in the package turns that into the one stylesheet the package cannot carry.

MIT. Live components, one playground page each, at https://arena.dravensoft.org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Arena by Dravensoft entry in the Tailwind CSS-based Angular UI libraries list.
  - Documented shared Angular and React components, reusable Tailwind layers, and contract-file governance.
  - Clarified that the library does not include built-in color palettes or fonts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->