### PR TITLE
Add rgaa-source to Accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [a11yguard](https://github.com/shamaz332/a11yguard) - Delivers a zero‑dependency accessibility toolkit with cross‑framework primitives, idiomatic adapters, and a runtime audit mapped to EAA / EN 301 549.
 * [ulam](https://github.com/mikeyil/ulam) - Accessibility utilities for the modern web. Vanilla-first, with optional React, Remix, Vue, and Angular adapters.
 * [aria-reach](https://github.com/manichandra/aria-reach) - ARIA accessibility anti-pattern analyzer for shared component libraries.
+* [rgaa-source](https://github.com/oussamaLaribi/RGAA) - Scans a built Angular app with axe-core and reports every violation with its template file and line instead of a CSS selector, plus safe automatic fixes and the French RGAA 4.1.2 audit grid.
 
 ### AI
 

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [a11yguard](https://github.com/shamaz332/a11yguard) - Delivers a zero‑dependency accessibility toolkit with cross‑framework primitives, idiomatic adapters, and a runtime audit mapped to EAA / EN 301 549.
 * [ulam](https://github.com/mikeyil/ulam) - Accessibility utilities for the modern web. Vanilla-first, with optional React, Remix, Vue, and Angular adapters.
 * [aria-reach](https://github.com/manichandra/aria-reach) - ARIA accessibility anti-pattern analyzer for shared component libraries.
-* [rgaa-source](https://github.com/oussamaLaribi/RGAA) - Scans a built Angular app with axe-core and reports every violation with its template file and line instead of a CSS selector, plus safe automatic fixes and the French RGAA 4.1.2 audit grid.
+* [rgaa-source](https://github.com/oussamaLaribi/RGAA) - Scans a built Angular app with axe-core and reports each violation with its originating template file and line when available, rather than only a CSS selector, plus safe automatic fixes and the French RGAA 4.1.2 audit grid.
 
 ### AI
 


### PR DESCRIPTION
Adds an Angular accessibility scanner to **Development Utilities → Accessibility**.

The section already covers ARIA primitives, guides and widgets. This one sits at
a different point in the workflow: it runs against your *built* app and maps each
finding back to the template that produced it.

**What it does.** It rewrites templates before the build to record every
element's `sourceSpan` position, so a violation axe-core finds in the rendered
DOM comes back as `checkout.component.html:42:8` rather than
`body > main > form > input.email`. It also applies mechanically safe fixes,
fills in the official French RGAA 4.1.2 audit grid, and supports a CI baseline so
builds fail on new violations rather than existing ones.

Verified on Angular 15 through 22, both `*ngIf` and `@if` syntaxes. MIT, runs
locally, nothing hosted.

Appended to the bottom of the category as the guidelines ask. One line added, no
trailing whitespace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `rgaa-source` reports template locations when available, alongside CSS selectors.
  * Documented its Angular application scanning, axe-core violation reporting, automatic fixes, and French RGAA 4.1.2 audit grid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->