### PR TITLE
Add Base UI (Angular) — CLI-first Angular + Tailwind copy-in library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2302,6 +2302,7 @@ for the creation of web applications developed with Angular.
 * [tailng](https://github.com/tociva/tailng) - Angular components styled with Tailwind to achieve a Material‑like look.
 * [volt-ui](https://github.com/Andersseen/volt-ui) - Fully accessible, themeable Angular components built with signals, Tailwind CSS v4, CVA, and `ng-primitives`.
 * [zapui](https://github.com/zapuilib/zapui) - Build scalable Angular apps with a Tailwind-powered design system from [zap:ui](https://zapui.togethercreative.co.uk/).
+* [Base UI (Angular)](https://github.com/Base-ui-ng/base-ui) - CLI-first Angular + Tailwind copy-in component library (shadcn-style): `npx base-ui-cli add` copies source into your repo. Docs at [base-ui.net](https://base-ui.net). Not MUI Base UI (React).
 
 ### UI Library and Framework Ionic
 


### PR DESCRIPTION
## What

Add **Base UI (Angular)** to **UI Libraries built on Tailwind CSS** (bottom of the category per contributing.md).

- Repo: https://github.com/Base-ui-ng/base-ui
- Docs: https://base-ui.net
- Install: `npx base-ui-cli add` copies source into the consumer repo (not an npm UI runtime).
- Distinct from [MUI Base UI](https://base-ui.com) (React).

Not a duplicate of Spartan (listed elsewhere): Spartan uses Helm copy-in plus `@spartan-ng/brain`; Base UI copies behavior and Tailwind source with no runtime UI package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Base UI (Angular) to the Tailwind CSS UI libraries list.
  * Included links to its repository and documentation, along with its CLI-based setup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->